### PR TITLE
docs: enforce PR workflow and prohibit direct push to main

### DIFF
--- a/.github/instructions/development-standards.instructions.md
+++ b/.github/instructions/development-standards.instructions.md
@@ -61,6 +61,14 @@
 
 ## Git Workflow
 - Branch strategy: `main` for production, `develop` for integration, `feature/*` for new work.
+- **NEVER push directly to `main` branch**. Always create a feature branch and submit a Pull Request.
+- Feature branch naming: `feature/<description>`, `fix/<description>`, `refactor/<description>`.
+- PR workflow:
+  1. Create feature branch from `main` or `develop`
+  2. Make commits following Conventional Commits format
+  3. Push feature branch to remote
+  4. Create Pull Request with clear description
+  5. Wait for review and approval before merging
 - Follow Conventional Commits (for example `feat:`, `fix:`, `docs:`, `refactor:`, `test:`).
 - Only commit or push when explicitly requested; keep the working state ready for commits at all times.
 


### PR DESCRIPTION
## Description

This PR updates the development standards to enforce proper Git workflow and prevent direct pushes to the `main` branch.

## Changes

- ✅ Add explicit rule: **NEVER push directly to main branch**
- ✅ Document complete PR workflow with 5 clear steps
- ✅ Add feature branch naming conventions (`feature/*`, `fix/*`, `refactor/*`)
- ✅ Clarify branch strategy: `main` (production), `develop` (integration), `feature/*` (new work)
- ✅ Ensure all future changes go through PR review process

## Modified Files

- `.github/instructions/development-standards.instructions.md`

## Workflow Steps (for future reference)

1. Create feature branch from `main` or `develop`
2. Make commits following Conventional Commits format
3. Push feature branch to remote
4. Create Pull Request with clear description
5. Wait for review and approval before merging

## Testing

- [x] Documentation changes reviewed
- [x] Instruction file structure preserved
- [x] Clear and actionable guidelines provided

## Related Issues

This addresses the need for a more structured development workflow to maintain code quality and enable proper review processes.
