### PR TITLE
fix: resolve shuffle + repeat queue loop issue

### DIFF
--- a/frontend/src/lib/audio/player.ts
+++ b/frontend/src/lib/audio/player.ts
@@ -124,15 +124,7 @@ class AudioPlayer {
    * Load and play a track
    */
   async play(track: Track): Promise<void> {
-    if (this.currentTrack?.id === track.id && this.howl) {
-      this.howl.stop();
-      this.howl.seek(0);
-      this.howl.play();
-      this.startProgressUpdate();
-      this.emit('play');
-      return;
-    }
-
+    // Always unload and create new Howl instance to ensure fresh event listeners
     this.unloadHowl();
     this.currentTrack = track;
     this.howl = this.createHowl(track);


### PR DESCRIPTION
## Problem

When using **Shuffle + Repeat Queue** mode, playback would hang after a track ended if the shuffled queue happened to have the same track at both the start and end positions.

## Root Cause

The player.play() method reused Howl instances for same track IDs, preventing 'end' event from firing again.

## Solution

- Remove Howl instance reuse optimization
- Always create new Howl instance to ensure fresh event listeners

## Testing

- Shuffle + Repeat Queue mode now works correctly
- Playback loops properly even when same track appears at queue boundaries