### PR TITLE
feat(player): improve HMR persistence and progress save reliability

### DIFF
--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -13,8 +13,18 @@ export function useNetworkStatus() {
   const [pendingSyncs, setPendingSyncs] = useState(0);
 
   useEffect(() => {
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
+    const handleOnline = () => {
+      setIsOnline(true);
+      // When browser goes online, optimistically assume API is reachable.
+      // NOTE: This may cause a brief UI inconsistency if the API is still unreachable (e.g., server down but network up).
+      // The next API call will correct isApiReachable via 'api-error'/'api-success' events.
+      setIsApiReachable(true);
+    };
+    
+    const handleOffline = () => {
+      setIsOnline(false);
+      setIsApiReachable(false);
+    };
 
     // Listen for API connectivity events
     const handleApiError = () => setIsApiReachable(false);

--- a/frontend/src/lib/audio/player.ts
+++ b/frontend/src/lib/audio/player.ts
@@ -470,6 +470,7 @@ class AudioPlayer {
       this.howl = null;
     }
     this.stopProgressUpdate();
+    this.pendingSeek = null; // Clear pending seek to avoid state issues
   }
 
   private canInitializeAudio(): boolean {

--- a/frontend/src/services/api/main/resources/player.ts
+++ b/frontend/src/services/api/main/resources/player.ts
@@ -70,8 +70,8 @@ export const player = {
   /**
    * Update playback progress
    */
-  updateProgress: async (data: UpdateProgressInput): Promise<void> => {
-    return mainApiClient.put(MAIN_API_ENDPOINTS.player.progress, data);
+  updateProgress: async (data: UpdateProgressInput, options?: RequestInit): Promise<void> => {
+    return mainApiClient.put(MAIN_API_ENDPOINTS.player.progress, data, options);
   },
 
   /**


### PR DESCRIPTION
## Overview

This PR resolves critical issues with player state persistence during HMR and playback progress saving, improving both development experience and user experience. Also fixes race conditions and improves offline handling.

---

## Key Improvements

### 1. HMR State Persistence (Window Backup)

**Problem:** Play bar disappears after HMR, or play button shows wrong state

**Solution:**
- Store player state in `window.__PLAYER_STATE_BACKUP__`
- Module variables reset on HMR, but window object survives
- Always read `isPlaying` from AudioPlayer instance to avoid stale state
- Subscribe to store updates and auto-save to window
- **DEV only**: Wrapped in `if (import.meta.env.DEV)` for zero production overhead

**Results:**
- ✅ Play bar persists after HMR
- ✅ Play button state matches actual playback
- ✅ Queue, progress, volume all restored correctly
- ✅ Production builds don't include HMR backup code

---

### 2. Progress Save Reliability

**Problem:** Debounce mechanism prevents saves when continuously triggered

**Solution:**
- **Remove debounce timeout** - `savePlaybackProgress()` executes immediately
- **5-second fixed interval** - Save every 5 seconds while playing
- **Immediate save** - Save once when song changes or play starts
- **Page unload save** - Use `fetch` with `keepalive: true` for guaranteed final save

**Why keepalive instead of sendBeacon:**
- sendBeacon only supports POST requests
- Backend endpoint uses PUT method
- keepalive allows PUT while ensuring request completes on page close

**Closure Bug Fix:**
- setInterval callback directly calls `savePlaybackProgress()`, no closure checks
- beforeunload uses `usePlayerStore.getState()` to read latest state
- Success log moved to `.then()` handler (only logs after actual success)

**Results:**
- ✅ Progress saves every 5 seconds reliably
- ✅ Page close/refresh guarantees final save with keepalive
- ✅ Stable PUT requests visible in Network panel

---

### 3. Offline Mode Graceful Handling

**Problem:** Offline repeat/shuffle toggle throws "requires internet connection" error

**Solution:**
- Check `navigator.onLine` before backend calls in `setRepeatMode()` / `toggleShuffle()`
- Only update local state when offline, skip API calls
- Auto-sync preferences via `loadPlaybackProgress()` when back online

**Results:**
- ✅ No errors when changing preferences offline
- ✅ Local state updates immediately
- ✅ Auto-sync to backend when online

---

### 4. Race Condition Prevention

**Problem:** Server preferences may overwrite user's immediate actions

**Scenario:**
1. User opens app, `loadPlaybackProgress()` starts async load
2. User immediately toggles shuffle (local state updated)
3. Server response arrives late, overwrites user's change

**Solution:**
- Add `hasUserModifiedPreferences` flag to track local changes
- Mark flag `true` when user calls `setRepeatMode()` or `toggleShuffle()`
- Skip server preference loading if flag is already `true`
- Ensures user actions always take precedence

**Results:**
- ✅ User changes never overwritten by stale server data
- ✅ Proper precedence: user action > server data

---

### 5. Network Recovery Optimization

**Problem:** Frontend stays offline after brief network interruption

**Solution:**
- `handleOnline` event sets both `isOnline` and `isApiReachable` to true
- Optimistic recovery: assume API reachable until next request fails

**Known Limitation:**
- May not work perfectly in all edge cases, but user feedback: "acceptable"
- Better solution requires periodic health check endpoint (future enhancement)

**Results:**
- ✅ Quick online mode recovery in most scenarios
- ⚠️ Rare edge cases may need manual retry

---

### 6. Code Cleanup

- Remove all `console.log('[DEBUG] ...')` statements
- Keep `logger.info/error` for production logging
- Clear `pendingSeek` in AudioPlayer to avoid state pollution
- Remove unused `currentTime` variable
- Update interface for async `setRepeatMode`

---

## Technical Details

### keepalive Implementation

```typescript
savePlaybackProgressSync: () => {
  const data = { songId, position, contextType, contextId, contextName };
  
  // Use fetch with keepalive for page unload (allows PUT method unlike sendBeacon)
  // keepalive ensures request completes even if page is already closing
  void api.main.player.updateProgress(data, { keepalive: true }).catch(() => {
    // Ignore errors during page unload (can't handle them anyway)
  });
}
```

**Key Points:**
- keepalive allows PUT requests (sendBeacon only POST)
- Browser auto-includes auth-token cookie
- Request queued even if page already closed
- Backend endpoint unchanged (still uses PUT)

---

### HMR State Recovery

```typescript
// Use window to store state (module variables reset)
const backupState = getBackupState();
const audioState = audioPlayer.getState();

return {
  currentSong: backupState?.currentSong ?? null,
  queue: backupState?.queue ?? [],
  isPlaying: audioState.isPlaying, // Read actual state from AudioPlayer
  // ... other fields from backup
};

// Subscribe to save state on every update (DEV only)
if (import.meta.env.DEV) {
  usePlayerStore.subscribe((state) => {
    setBackupState({ ...all state fields... });
  });
}
```

**Key Points:**
- AudioPlayer singleton survives HMR
- Store module resets but window object doesn't
- `isPlaying` must come from AudioPlayer to avoid stale state
- Production builds exclude backup code via tree-shaking

---

### Race Condition Prevention

```typescript
interface PlayerState {
  // ... other fields
  hasLoadedPreferences: boolean;
  hasUserModifiedPreferences: boolean;
}

loadPlaybackProgress: async () => {
  // Skip if user has already modified preferences locally
  const { hasUserModifiedPreferences } = get();
  if (!hasUserModifiedPreferences) {
    const preferences = await api.main.player.getPreferences();
    set({ 
      repeatMode: preferences.repeatMode,
      hasLoadedPreferences: true 
    });
  } else {
    logger.info('Skipped loading preferences - user has local changes');
  }
}

setRepeatMode: async (mode) => {
  set({ repeatMode: mode, hasUserModifiedPreferences: true }); // Mark modified
  // ... save to backend
}
```

**Key Points:**
- Flag prevents late server response from overwriting user changes
- User actions always take precedence over async loads
- Simple boolean flag, no complex timestamp comparison

---

### Closure Trap Fix

**Problem Code:**
```typescript
// ❌ Closure captures stale currentSong and currentTime
useEffect(() => {
  const interval = setInterval(() => {
    if (currentSong && currentTime > 0) {
      savePlaybackProgress(); // Always reads old closure values
    }
  }, 5000);
}, [currentSong, isPlaying]);
```

**Fixed:**
```typescript
// ✅ Directly call savePlaybackProgress, reads latest state internally
useEffect(() => {
  const interval = setInterval(() => {
    savePlaybackProgress(); // Always reads latest store state
  }, 5000);
}, [currentSong?.id, isPlaying]);
```

---

## Testing

- ✅ HMR preserves play bar and correct button state
- ✅ Progress saves every 5 seconds (visible in Network panel)
- ✅ Page refresh/close saves via keepalive
- ✅ Offline preference changes work without errors
- ✅ Network recovery switches to online mode (most cases)
- ✅ Race condition prevented (tested with immediate user actions)
- ✅ All TypeScript compiles, no lint errors

---

## Changed Files

| File | Changes | Description |
|------|---------|-------------|
| `playerStore.ts` | +177/-68 | Major refactor: window backup, keepalive, race condition fix |
| `player.ts` (resource) | +3/-2 | Add keepalive support to updateProgress |
| `mobile-layout.tsx` | +36/-9 | Progress save refactor, add beforeunload |
| `useNetworkStatus.ts` | +12/-2 | Network recovery optimization |
| `player.ts` (audio) | +1 | Clear pendingSeek |

---

## Future Work

- [ ] Verify keepalive success rate in production
- [ ] Monitor backend logs to confirm PUT requests work correctly
- [ ] Consider health check endpoint for better network recovery (optional)
- [ ] Add PWA offline caching strategies (future PR)

---

## References

- [Player Store Architecture](../frontend/src/stores/playerStore.ts)
- [Audio Player Implementation](../frontend/src/lib/audio/player.ts)
- [Development Standards](./.github/instructions/development-standards.instructions.md)