### PR TITLE
refactor: remove Redis dependency completely

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@
 - M3W is a self-hosted music player with separated frontend/backend architecture that prioritizes full library ownership and offline resilience.
 - Core online features complete: multi-library management, cross-library playlists, mobile-first UI, playback state management with HMR persistence.
 - Current focus: Offline experience design - PWA integration, IndexedDB caching, background sync, and graceful degradation.
-- Core stack: Vite 5 + React 19 (frontend), Hono 4 + Node.js (backend), Prisma/PostgreSQL, MinIO, Redis (reserved), shadcn/ui, Tailwind CSS v4, PWA (in progress), Dexie IndexedDB (planned).
+- Core stack: Vite 5 + React 19 (frontend), Hono 4 + Node.js (backend), Prisma/PostgreSQL, MinIO, shadcn/ui, Tailwind CSS v4, PWA (in progress), Dexie IndexedDB (planned).
 - Internationalization: Custom Proxy-based i18n system with full type safety and reactive language switching.
 - Frontend API: Unified service layer with type-safe clients (see project-context for details).
 
@@ -43,7 +43,7 @@
 
 ## Core Context Highlights
 
-- **Architecture**: Separated frontend/backend with Vite SPA frontend and Hono REST API backend, Prisma for PostgreSQL, MinIO for deduplicated audio storage, Redis earmarked for caching.
+- **Architecture**: Separated frontend/backend with Vite SPA frontend and Hono REST API backend, Prisma for PostgreSQL, MinIO for deduplicated audio storage.
 - **Primary domains**: Library management, playlist authoring and ordering, upload deduplication with metadata extraction, offline playback via IndexedDB and Service Worker.
 - **Current phase**: Online features complete (mobile-first UI, multi-library, playlists, player state). Next milestone: Offline experience (PWA, caching, sync).
 

--- a/.github/instructions/development-standards.instructions.md
+++ b/.github/instructions/development-standards.instructions.md
@@ -26,10 +26,10 @@
 - Audio streaming uses API proxy pattern (`/api/songs/[songId]/stream`) with Range request support; MinIO is never exposed to clients and remains internal to the backend network.
 - Metadata extraction prioritizes user edits over backend extraction, and backend extraction over frontend extraction.
 - Environment configuration requires separate `.env` files for frontend and backend.
-- Backend environment variables in `backend/.env` (DATABASE_URL, JWT_SECRET, GITHUB_CLIENT_*, MinIO, Redis).
+- Backend environment variables in `backend/.env` (DATABASE_URL, JWT_SECRET, GITHUB_CLIENT_*, MinIO).
 - Frontend environment variables in `frontend/.env` (VITE_API_URL).
 - Container environments use `.env.docker` with `host.containers.internal` to access host services; local development uses `.env` with `localhost`.
-- When the production container joins the docker-compose network (`m3w_default`), use container service names (`m3w-postgres`, `m3w-redis`, `m3w-minio`) instead of `host.containers.internal`.
+- When the production container joins the docker-compose network (`m3w_default`), use container service names (`m3w-postgres`, `m3w-minio`) instead of `host.containers.internal`.
 - Authentication uses JWT tokens with GitHub OAuth; no session database.
 - PWA with offline-first architecture using IndexedDB via Dexie and Service Worker with Workbox.
 - User feedback flows through the toast store defined in `frontend/src/components/ui/use-toast.ts` with a single `<Toaster />` in `frontend/src/main.tsx`.
@@ -75,7 +75,7 @@
 ## Local Production Testing
 - Build production images with `podman build -t m3w:local -f docker/Dockerfile .` or equivalent Docker command.
 - Use `.env.docker` (created from `.env.docker.example`) for container environments.
-- When using docker-compose services, the container must join the `m3w_default` network to access PostgreSQL, Redis, and MinIO via their container names (`m3w-postgres`, `m3w-redis`, `m3w-minio`).
+- When using docker-compose services, the container must join the `m3w_default` network to access PostgreSQL and MinIO via their container names (`m3w-postgres`, `m3w-minio`).
 - Run containers with `podman run -d --name m3w-prod --network m3w_default -p 4000:4000 --env-file backend/.env.docker m3w:local`.
 - For standalone containers without compose, use `host.containers.internal` in `.env.docker` to access host services.
 - Verify builds pass type checking, linting, and produce functional containers before deployment.

--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -5,7 +5,7 @@
 ### Architecture Overview
 
 **Frontend**: Vite 5 + React 19 + React Router 6
-**Backend**: Hono 4 (Node.js) + Prisma + PostgreSQL + MinIO + Redis
+**Backend**: Hono 4 (Node.js) + Prisma + PostgreSQL + MinIO
 
 The project has been **migrated from Next.js to a separated frontend/backend architecture**:
 - **Frontend** (`/frontend`): Pure SPA using Vite, React Router, and TanStack Query
@@ -112,7 +112,6 @@ The project has been **migrated from Next.js to a separated frontend/backend arc
 ### Planned Initiatives (Upcoming)
 - **Core Product Enhancements**
   - Enhanced user profile management
-  - Redis integration for caching
   - Testing expansion (Playwright end-to-end, coverage targets)
 - **PWA Enhancements**
   - Background sync for offline mutations
@@ -330,8 +329,8 @@ m3w/
 │  ├── Logging (hono/logger + Pino)          │
 │  └── Rate Limiting (Future)                 │
 └─────────────────────────────────────────────┘
-          ↓           ↓           ↓
-    PostgreSQL     Redis      MinIO
+          ↓           ↓
+    PostgreSQL     MinIO
 ```
 
 ### Technology Stack
@@ -357,7 +356,6 @@ m3w/
 - **Framework**: Hono 4 (Node.js)
 - **ORM**: Prisma
 - **Database**: PostgreSQL 16
-- **Cache**: Redis 7
 - **File Storage**: MinIO (S3-compatible)
 - **Authentication**: JWT (jsonwebtoken) with GitHub OAuth
 - **Validation**: Zod
@@ -383,14 +381,13 @@ Local Development:
 - Podman Desktop or Docker Desktop
 - Next.js app (dev mode)
 - PostgreSQL
-- Redis
 - MinIO
 
 Production:
 - Kubernetes deployment
 - Container runtime: containerd
 - Ingress: Nginx or Traefik
-- Stateful services for PostgreSQL, Redis, MinIO
+- Stateful services for PostgreSQL, MinIO
 - Persistent volumes
 - CI/CD via GitHub Actions
 - Container registry: Docker Hub (official images)
@@ -484,7 +481,6 @@ Observability plans include Pino logging, optional Prometheus and Grafana, optio
 ### Scalability Considerations
 - Both frontend and backend are stateless and support horizontal scaling.
 - JWT tokens enable stateless authentication across multiple instances.
-- Redis provides shared caching.
 - Future microservice extraction possible with clear backend separation.
 - Integration points reserved for message queues, search, object storage, email, and upload pipelines.
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -147,7 +147,6 @@ jobs:
         env:
           # Mock environment variables for build
           DATABASE_URL: postgresql://mock:mock@localhost:5432/mock
-          REDIS_URL: redis://localhost:6379
           JWT_SECRET: mock-jwt-secret-for-build-only-must-be-at-least-32-chars
           JWT_ACCESS_EXPIRY: 6h
           JWT_REFRESH_EXPIRY: 90d
@@ -173,7 +172,6 @@ jobs:
         working-directory: backend
         env:
           DATABASE_URL: postgresql://mock:mock@localhost:5432/mock
-          REDIS_URL: redis://localhost:6379
           JWT_SECRET: mock-jwt-secret-for-build-only-must-be-at-least-32-chars
           MINIO_ENDPOINT: localhost
           MINIO_PORT: 9000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # M3W - Music Player
 
-Production-grade self-hosted music player built with Vite, Hono, PostgreSQL, and Redis.
+Production-grade self-hosted music player built with Vite, Hono, and PostgreSQL.
 
 ## Tech Stack
 
@@ -20,7 +20,6 @@ Production-grade self-hosted music player built with Vite, Hono, PostgreSQL, and
 - **Framework**: Hono 4 (Node.js 25.1.0)
 - **Language**: TypeScript 5
 - **Database**: PostgreSQL 16 (Prisma ORM)
-- **Cache**: Redis 7
 - **Storage**: MinIO (S3-compatible)
 - **Authentication**: JWT with GitHub OAuth
 - **Logging**: Pino
@@ -96,7 +95,7 @@ The setup script will:
 
 - Install dependencies for root, frontend, backend, and shared packages
 - Create `backend/.env` and `frontend/.env` from templates
-- Start PostgreSQL, Redis, and MinIO containers (using Docker Hub images)
+- Start PostgreSQL and MinIO containers (using Docker Hub images)
 - Run database migrations
 - Provide next steps
 
@@ -171,7 +170,6 @@ podman-compose up -d
 This will start:
 
 - PostgreSQL on `localhost:5432`
-- Redis on `localhost:6379`
 - MinIO on `localhost:9000`
 
 ### 4. Run Database Migrations
@@ -358,7 +356,6 @@ All major UI/UX issues have been resolved! ✅
 ### 📋 Backlog
 
 - Enhanced user profile management (edit name, email)
-- Redis integration for caching
 - Testing expansion (Playwright E2E tests, coverage targets)
 - PWA background sync for offline mutations
 - Push notifications for sync status
@@ -521,7 +518,7 @@ docker build -t m3w:local -f docker/Dockerfile .
 
 #### 3. Run Production Container
 
-**Important**: The container must join the `m3w_default` network created by docker-compose to access PostgreSQL, Redis, and MinIO.
+**Important**: The container must join the `m3w_default` network created by docker-compose to access PostgreSQL and MinIO.
 
 ```bash
 # With Podman
@@ -555,7 +552,7 @@ docker rm m3w-prod
 
 **Key Differences in `.env.docker`:**
 
-- Use container service names (`m3w-postgres`, `m3w-redis`, `m3w-minio`) instead of `localhost` when the container joins the compose network
+- Use container service names (`m3w-postgres`, `m3w-minio`) instead of `localhost` when the container joins the compose network
 - Set `NODE_ENV=production`
 - Configure proxy with `host.containers.internal` if needed for external API access (e.g., GitHub OAuth)
 

--- a/backend/.env.docker.example
+++ b/backend/.env.docker.example
@@ -3,9 +3,6 @@
 # Otherwise use host.containers.internal to access host services
 DATABASE_URL=postgresql://postgres:postgres@m3w-postgres:5432/m3w?schema=public
 
-# Redis
-REDIS_URL=redis://m3w-redis:6379
-
 # MinIO (S3-compatible storage)
 MINIO_ENDPOINT=m3w-minio
 MINIO_PORT=9000

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,9 +1,6 @@
 # Database
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/m3w?schema=public
 
-# Redis
-REDIS_URL=redis://localhost:6379
-
 # MinIO (S3-compatible storage)
 MINIO_ENDPOINT=localhost
 MINIO_PORT=9000

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -47,7 +47,7 @@ const envVars = Object.entries(process.env)
     // Only show M3W-related and common dev variables
     return (
       key.startsWith('DATABASE_') ||
-      key.startsWith('REDIS_') ||
+
       key.startsWith('MINIO_') ||
       key.startsWith('JWT_') ||
       key.startsWith('GITHUB_') ||

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -427,9 +427,10 @@ app.get('/session', authMiddleware, async (c: Context) => {
   }
 });
 
-// POST /api/auth/logout - Logout (optional: could invalidate tokens in Redis)
+// POST /api/auth/logout - Logout
 app.post('/logout', authMiddleware, async (c: Context) => {
-  // TODO: Add token to blacklist in Redis if needed
+  // Note: Using stateless JWT, no server-side session invalidation needed
+  // Client should delete tokens on logout
   return c.json({
     success: true,
     message: 'Logged out successfully',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,21 +18,6 @@ services:
       timeout: 5s
       retries: 5
 
-  redis:
-    # Using official Redis image (preferred for stability)
-    image: redis:7-alpine
-    container_name: m3w-redis
-    restart: unless-stopped
-    ports:
-      - "6379:6379"
-    volumes:
-      - redis_data:/data
-    healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
   minio:
     # MinIO for S3-compatible object storage
     image: minio/minio:latest
@@ -55,5 +40,4 @@ services:
 
 volumes:
   postgres_data:
-  redis_data:
   minio_data:

--- a/docs/CHINA_REGISTRY.md
+++ b/docs/CHINA_REGISTRY.md
@@ -226,8 +226,8 @@ Combine proxy with mirrors for maximum reliability:
 # Test PostgreSQL image
 podman pull postgres:16-alpine
 
-# Test Redis image
-podman pull redis:7-alpine
+# Test MinIO image
+podman pull minio/minio:latest
 
 ```
 
@@ -363,15 +363,15 @@ If all else fails, you can download images on a machine with internet access:
 ```bash
 # On a machine with internet access
 podman pull postgres:16-alpine
-podman pull redis:7-alpine
+podman pull minio/minio:latest
 
 # Save images to files
 podman save -o postgres-16-alpine.tar postgres:16-alpine
-podman save -o redis-7-alpine.tar redis:7-alpine
+podman save -o minio-latest.tar minio/minio:latest
 
 # Transfer files to your machine, then load:
 podman load -i postgres-16-alpine.tar
-podman load -i redis-7-alpine.tar
+podman load -i minio-latest.tar
 ```
 
 ---

--- a/docs/LAN_ACCESS.md
+++ b/docs/LAN_ACCESS.md
@@ -98,7 +98,6 @@ You need to allow the following ports:
 - **4000**: Hono backend API
 - **5432**: PostgreSQL (if you need to access database from other machines)
 - **9000**: MinIO (if direct access is needed)
-- **6379**: Redis (if direct access is needed)
 
 #### Method 1: Using PowerShell (Administrator privileges required)
 

--- a/docs/PODMAN.md
+++ b/docs/PODMAN.md
@@ -84,7 +84,7 @@ podman machine list        # Should show running machine (Windows/macOS)
 # Navigate to project directory
 cd m3w
 
-# Start PostgreSQL and Redis
+# Start PostgreSQL and MinIO
 podman-compose up -d
 
 # Check running containers

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -36,7 +36,6 @@
     "build",
     "src/app",
     "src/lib/logger.ts",
-    "src/lib/redis",
     "src/lib/storage/minio-client.ts",
     "src/test/fixtures"
   ]


### PR DESCRIPTION
## 📝 Summary

Completely remove Redis dependency from the project as it is not needed for a self-hosted music player use case.

## 🎯 Motivation

After analysis, Redis provides no practical benefit for M3W:
- **Low concurrency**: Self-hosted for single user or small teams
- **Stateless JWT**: No session storage needed
- **Small data volume**: PostgreSQL handles it easily
- **Client-side caching**: TanStack Query + PWA IndexedDB already in place

Keeping Redis adds unnecessary:
- Container resource usage
- Deployment complexity
- Maintenance overhead

## 🔧 Changes

### Infrastructure
- ✅ Removed Redis service from `docker-compose.yml`
- ✅ Removed `redis_data` volume

### Configuration
- ✅ Removed `REDIS_URL` from `backend/.env.example`
- ✅ Removed `REDIS_URL` from `backend/.env.docker.example`

### Code
- ✅ Cleaned up Redis references in `backend/src/index.ts`
- ✅ Updated logout route comment in `backend/src/routes/auth.ts`
- ✅ Removed Redis exclude path from `frontend/tsconfig.json`

### CI/CD
- ✅ Updated GitHub Actions workflow (`pr-check.yml`)
- ✅ Removed `REDIS_URL` from build and test environment variables

### Documentation
- ✅ Updated `README.md` (tech stack, service list, backlog)
- ✅ Updated `.github/copilot-instructions.md`
- ✅ Updated `.github/instructions/project-context.instructions.md`
- ✅ Updated `.github/instructions/development-standards.instructions.md`
- ✅ Updated `docs/PODMAN.md`
- ✅ Updated `docs/LAN_ACCESS.md`
- ✅ Updated `docs/CHINA_REGISTRY.md`

## ✅ Testing

All changes are configuration and documentation updates. No functional code changes.

Verified:
- [x] All Redis references removed (global search returns 0 matches)
- [x] Docker Compose validates successfully
- [x] Environment variable examples are consistent
- [x] Documentation is up to date

## 📦 Impact

**Breaking Changes**: None (Redis was configured but never used in code)

**New Stack**:
```
Frontend: TanStack Query (API caching)
Backend: Stateless (JWT tokens)
Offline: PWA + IndexedDB (via Dexie)
```

## 🚀 Next Steps

After merge:
1. Update local `.env` files (remove `REDIS_URL`)
2. Restart services: `docker-compose down -v && docker-compose up -d`
3. Verify services run with only PostgreSQL and MinIO

## 📚 References

- Discussion: Architecture simplification for self-hosted use case
- Related: PWA offline strategy (in progress)