### PR TITLE
feat: expose absolute cover urls

### DIFF
--- a/.github/instructions/development-standards.instructions.md
+++ b/.github/instructions/development-standards.instructions.md
@@ -23,6 +23,7 @@
 
 ## Key Technical Decisions
 - File storage uses hash-based deduplication with reference counting; metadata remains user-specific.
+- Audio cover art is extracted during upload, stored in MinIO under `covers/{fileHash}.jpg`, and always exposed as an absolute URL (built from `API_BASE_URL` + `/api/songs/:id/cover`) via the cover URL helper so future migrations (for example presigned URLs) do not require data changes and the fully separated frontend can consume the value directly.
 - Audio streaming uses API proxy pattern (`/api/songs/[songId]/stream`) with Range request support; MinIO is never exposed to clients and remains internal to the backend network.
 - Metadata extraction prioritizes user edits over backend extraction, and backend extraction over frontend extraction.
 - Environment configuration requires separate `.env` files for frontend and backend.

--- a/backend/.env.docker.example
+++ b/backend/.env.docker.example
@@ -25,6 +25,7 @@ GITHUB_CALLBACK_URL=http://localhost:4000/api/auth/callback
 PORT=4000
 HOST=0.0.0.0
 CORS_ORIGIN=http://localhost:3000
+API_BASE_URL=http://localhost:4000
 
 # Node Environment
 NODE_ENV=production

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -24,6 +24,7 @@ GITHUB_CALLBACK_URL=http://localhost:4000/api/auth/callback
 PORT=4000
 HOST=0.0.0.0
 CORS_ORIGIN=http://localhost:3000
+# Base URL exposed to clients (cover URLs, streaming endpoints, etc.)
 API_BASE_URL=http://localhost:4000
 
 # Node Environment

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -931,20 +931,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/@prisma/config/node_modules/magicast": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
-      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/parser": "^7.25.4",
-        "@babel/types": "^7.25.4",
-        "source-map-js": "^1.2.0"
-      }
-    },
     "node_modules/@prisma/debug": {
       "version": "6.19.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.0.tgz",
@@ -1447,6 +1433,7 @@
       "integrity": "sha512-tK3GPFWbirvNgsNKto+UmB/cRtn6TZfyw0D6IKrW55n6Vbs7KJoZtI//kpTKzE/DUmmnAFD8/Ca46s7Obs92/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.4",
         "@typescript-eslint/types": "8.46.4",
@@ -1828,6 +1815,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2453,6 +2441,7 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3114,6 +3103,7 @@
       "resolved": "https://registry.npmmirror.com/hono/-/hono-4.10.4.tgz",
       "integrity": "sha512-YG/fo7zlU3KwrBL5vDpWKisLYiM+nVstBQqfr7gCPbSYURnNEP9BDxEMz8KfsDR9JX0lJWDRNc6nXX31v7ZEyg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3393,6 +3383,7 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4155,6 +4146,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.0",
         "@prisma/engines": "6.19.0"
@@ -4755,6 +4747,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4832,6 +4825,7 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -4865,6 +4859,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4927,6 +4922,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5020,6 +5016,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5033,6 +5030,7 @@
       "integrity": "sha512-urzu3NCEV0Qa0Y2PwvBtRgmNtxhj5t5ULw7cuKhIHh3OrkKTLlut0lnBOv9qe5OvbkMH2g38G7KPDCTpIytBVg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.8",
         "@vitest/mocker": "4.0.8",

--- a/backend/src/lib/cover-url-helper.ts
+++ b/backend/src/lib/cover-url-helper.ts
@@ -1,0 +1,116 @@
+/**
+ * Cover URL Helper
+ * 
+ * Handles conversion between storage paths and API URLs for cover images.
+ * 
+ * Design Decision:
+ * - Database stores MinIO relative paths: "covers/{fileHash}.jpg"
+ * - API returns accessible URLs: "/api/songs/{songId}/cover"
+ * 
+ * Benefits:
+ * - Storage-agnostic: Can migrate MinIO → S3 → OSS without DB changes
+ * - Future-proof: Can switch to presigned URLs without data migration
+ * - Security: All access goes through authenticated API
+ * - Multi-environment: Same DB data works across dev/staging/prod
+ */
+
+interface SongWithCover {
+  id: string;
+  coverUrl: string | null;
+}
+
+function getApiBaseUrl(): string {
+  const explicitBase = process.env.API_BASE_URL;
+  if (explicitBase && explicitBase.trim().length > 0) {
+    return explicitBase;
+  }
+
+  const port = process.env.PORT || '4000';
+  return `http://localhost:${port}`;
+}
+
+/**
+ * Convert storage path to API URL
+ * 
+ * @param song - Song object with id and coverUrl
+ * @returns API URL for cover image or null if no cover
+ * 
+ * @example
+ * // MinIO path → API path
+ * resolveCoverUrl({ id: "song123", coverUrl: "covers/abc.jpg" })
+ * // Returns: "/api/songs/song123/cover"
+ * 
+ * @example
+ * // External URL → unchanged
+ * resolveCoverUrl({ id: "song123", coverUrl: "https://example.com/cover.jpg" })
+ * // Returns: "https://example.com/cover.jpg"
+ * 
+ * @example
+ * // No cover → null
+ * resolveCoverUrl({ id: "song123", coverUrl: null })
+ * // Returns: null
+ */
+export function resolveCoverUrl(song: SongWithCover): string | null {
+  if (!song.coverUrl) return null;
+
+  // External URL: return as-is (for future external API integration)
+  if (song.coverUrl.startsWith('http://') || song.coverUrl.startsWith('https://')) {
+    return song.coverUrl;
+  }
+
+  // MinIO relative path: convert to absolute API URL so the frontend can use it directly
+  const apiBase = getApiBaseUrl();
+  const coverPath = `/api/songs/${song.id}/cover`;
+  return new URL(coverPath, apiBase).toString();
+}
+
+/**
+ * Batch convert cover URLs for multiple songs
+ * 
+ * @param songs - Array of song objects
+ * @returns Array with resolved cover URLs
+ * 
+ * @example
+ * const songs = [
+ *   { id: "1", coverUrl: "covers/a.jpg" },
+ *   { id: "2", coverUrl: null }
+ * ];
+ * resolveCoverUrls(songs);
+ * // Returns: [
+ * //   { id: "1", coverUrl: "/api/songs/1/cover" },
+ * //   { id: "2", coverUrl: null }
+ * // ]
+ */
+export function resolveCoverUrls<T extends SongWithCover>(songs: T[]): T[] {
+  return songs.map(song => ({
+    ...song,
+    coverUrl: resolveCoverUrl(song),
+  }));
+}
+
+/**
+ * Future Enhancement: Generate presigned URL for direct MinIO access
+ * 
+ * This will reduce backend load by allowing frontend to fetch images directly
+ * from MinIO using temporary signed URLs (valid for 1 hour).
+ * 
+ * Implementation guide:
+ * 1. Check if coverUrl is MinIO path (not external URL)
+ * 2. Call minioClient.presignedGetObject(bucket, coverUrl, 3600)
+ * 3. Return signed URL
+ * 
+ * No database migration needed - just change this helper function.
+ * 
+ * @example
+ * // Future implementation
+ * export async function resolvePresignedCoverUrl(
+ *   song: SongWithCover,
+ *   minioClient: MinioClient
+ * ): Promise<string | null> {
+ *   if (!song.coverUrl) return null;
+ *   if (song.coverUrl.startsWith('http')) return song.coverUrl;
+ *   
+ *   const bucket = process.env.MINIO_BUCKET_NAME || 'm3w-music';
+ *   return await minioClient.presignedGetObject(bucket, song.coverUrl, 3600);
+ * }
+ */

--- a/backend/src/routes/player.ts
+++ b/backend/src/routes/player.ts
@@ -8,6 +8,7 @@ import { z, ZodError } from 'zod';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { authMiddleware } from '../lib/auth-middleware';
+import { resolveCoverUrl } from '../lib/cover-url-helper';
 import type { Context } from 'hono';
 
 const app = new Hono();
@@ -115,7 +116,7 @@ app.get('/seed', async (c: Context) => {
             title: playlistSong.title,
             artist: playlistSong.artist,
             album: playlistSong.album,
-            coverUrl: playlistSong.coverUrl,
+            coverUrl: resolveCoverUrl({ id: playlistSong.id, coverUrl: playlistSong.coverUrl }),
             duration: playlistSong.file.duration ?? undefined,
             audioUrl,
             mimeType: playlistSong.file.mimeType ?? undefined,
@@ -177,7 +178,7 @@ app.get('/seed', async (c: Context) => {
             title: librarySong.title,
             artist: librarySong.artist,
             album: librarySong.album,
-            coverUrl: librarySong.coverUrl,
+            coverUrl: resolveCoverUrl({ id: librarySong.id, coverUrl: librarySong.coverUrl }),
             duration: librarySong.file.duration ?? undefined,
             audioUrl,
             mimeType: librarySong.file.mimeType ?? undefined,
@@ -370,7 +371,7 @@ app.get('/progress', async (c: Context) => {
           title: song.title,
           artist: song.artist,
           album: song.album,
-          coverUrl: song.coverUrl,
+          coverUrl: resolveCoverUrl({ id: song.id, coverUrl: song.coverUrl }),
           duration: song.file.duration ?? undefined,
           audioUrl,
           mimeType: song.file.mimeType ?? undefined,


### PR DESCRIPTION
## Summary
- add a cover URL helper so every song response returns an absolute cover URL built from `API_BASE_URL`
- document the decision and update env examples so all environments expose the correct base URL
- ensure all song-facing routes consume the helper and keep the API stable for the split frontend

## Testing
- `npm run build` (backend)
