### PR TITLE
fix: add missing coverUrl resolution in playlist songs and upload APIs

### DIFF
--- a/backend/src/routes/playlists.ts
+++ b/backend/src/routes/playlists.ts
@@ -361,6 +361,7 @@ app.get('/:id/songs', async (c: Context) => {
       .map((song) => ({
         ...song,
         libraryName: song.library.name,
+        coverUrl: resolveCoverUrl({ id: song.id, coverUrl: song.coverUrl }),
       }));
 
     return c.json({

--- a/backend/src/routes/upload.ts
+++ b/backend/src/routes/upload.ts
@@ -12,6 +12,7 @@ import { getMinioClient } from '../lib/minio-client';
 import { logger } from '../lib/logger';
 import { authMiddleware } from '../lib/auth-middleware';
 import { getUserId } from '../lib/auth-helper';
+import { resolveCoverUrl } from '../lib/cover-url-helper';
 
 // Compile-time constant injected by tsup for tree-shaking
 declare const __IS_DEMO_BUILD__: boolean;
@@ -319,7 +320,10 @@ app.post('/', async (c: Context) => {
     return c.json({
       success: true,
       data: {
-        song,
+        song: {
+          ...song,
+          coverUrl: resolveCoverUrl({ id: song.id, coverUrl: song.coverUrl }),
+        },
         file: fileRecord,
         isNewFile,
       },


### PR DESCRIPTION
## Problem

Playlist song covers were showing as broken images because the API was returning raw MinIO storage paths (e.g., `covers/{hash}.jpg`) instead of API URLs.

## Root Cause

Two API endpoints were missing `resolveCoverUrl()` transformation:
1. `GET /api/playlists/:id/songs` - Returns playlist songs
2. `POST /api/upload` - Returns newly uploaded song

## Changes

### `backend/src/routes/playlists.ts`
- Added `resolveCoverUrl()` to transform song covers in playlist songs response
- Ensures covers are returned as `/api/songs/{id}/cover` URLs

### `backend/src/routes/upload.ts`
- Added `resolveCoverUrl()` import and transformation
- Ensures newly uploaded songs return proper cover URLs

## Testing

✅ All other endpoints already correctly use `resolveCoverUrl()`:
- `GET /api/libraries` (line 52)
- `GET /api/libraries/:id/songs` (line 405)
- `GET /api/playlists` (line 60)
- `GET /api/songs` (line 127)
- `GET /api/songs/:id` (line 189)
- `GET /api/player/seed` (line 126, 175)
- `GET /api/player/progress` (line 397)

## Verification

After this fix:
- Playlist song covers load correctly in detail view
- Newly uploaded song covers display immediately
- All cover URLs are consistent across the API

Closes #42