### PR TITLE
fix: unify no cover placeholder across player components

### DIFF
--- a/frontend/src/components/features/player/full-player.tsx
+++ b/frontend/src/components/features/player/full-player.tsx
@@ -10,6 +10,7 @@ import {
   ChevronDown,
   Heart,
   ListMusic,
+  Music,
   Play,
   Pause,
   SkipBack,
@@ -113,7 +114,7 @@ export function FullPlayer() {
             />
           ) : (
             <div className="flex h-full w-full items-center justify-center bg-muted">
-              <span className="text-4xl text-muted-foreground">♪</span>
+              <Music className="h-20 w-20 text-muted-foreground/30" />
             </div>
           )}
         </div>

--- a/frontend/src/components/features/player/mini-player.tsx
+++ b/frontend/src/components/features/player/mini-player.tsx
@@ -3,7 +3,7 @@
  * Compact player displayed above bottom navigation
  */
 
-import { Play, Pause, SkipForward } from 'lucide-react';
+import { Play, Pause, SkipForward, Music } from 'lucide-react';
 import { usePlayerStore } from '@/stores/playerStore';
 import { useUIStore } from '@/stores/uiStore';
 import { cn } from '@/lib/utils';
@@ -32,8 +32,8 @@ export function MiniPlayer() {
               className="h-full w-full object-cover"
             />
           ) : (
-            <div className="flex h-full w-full items-center justify-center text-xs text-muted-foreground">
-              No Cover
+            <div className="flex h-full w-full items-center justify-center bg-muted">
+              <Music className="h-6 w-6 text-muted-foreground/30" />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Problem

The no-cover placeholder was inconsistent across player components:
- **MiniPlayer**: Text "No Cover"
- **FullPlayer**: Music note symbol "♪"
- **List cards**: Music icon

This creates visual inconsistency in the UI.

## Changes

Unified all no-cover placeholders to use the `<Music />` icon from lucide-react:

### `mini-player.tsx`
- Replaced text "No Cover" with `<Music className="h-6 w-6 text-muted-foreground/30" />`
- Matches the compact size of mini player

### `full-player.tsx`
- Replaced music note symbol "♪" with `<Music className="h-20 w-20 text-muted-foreground/30" />`
- Larger icon scale appropriate for full-screen player

## Visual Consistency

Now all no-cover states use the same icon:
- ✅ MiniPlayer: Music icon (h-6)
- ✅ FullPlayer: Music icon (h-20)
- ✅ Library cards: Music icon (h-10)
- ✅ Playlist cards: Music icon (h-10)
- ✅ Song lists: Music icon (h-5)

All use consistent color: `text-muted-foreground/30`

## Screenshots

**Before**: Text and symbol varied
**After**: Consistent Music icon across all components

Related to #42