### PR TITLE
docs: add project management section to instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@
 | File | Applies To | Purpose |
 | --- | --- | --- |
 | `.github/instructions/project-context.instructions.md` | `**/*` | Full project status, architecture, and domain context |
-| `.github/instructions/development-standards.instructions.md` | `**/*` | Coding conventions, testing strategy, and workflow agreements |
+| `.github/instructions/development-standards.instructions.md` | `**/*` | Coding conventions, testing strategy, workflow agreements, and **project management** |
 | `.github/instructions/api-patterns.instructions.md` | `**/*` | API response pattern and toast feedback workflow |
 | `.github/instructions/i18n-system.instructions.md` | `**/*` | Internationalization architecture and usage patterns |
 | `.github/instructions/user-stories.instructions.md` | `**/*` | Complete product requirements (online + offline experience) |
@@ -39,6 +39,7 @@
 
 - Need business context, core flows, or roadmap? Open `project-context.instructions.md`.
 - Touching code style, typing, Git flow, or testing? Review `development-standards.instructions.md`.
+- **Managing issues, epics, or milestones?** See the Project Management section in `development-standards.instructions.md`.
 - Writing or adjusting an API route or toast feedback? Follow `api-patterns.instructions.md` for consistent response structure and user notifications.
 - Adding or modifying user-facing text? Follow `i18n-system.instructions.md` for proper i18n integration.
 - Understanding product requirements (online or offline)? Check `user-stories.instructions.md` for complete user flows and acceptance criteria.
@@ -67,6 +68,8 @@
 - i18n system: [i18n-system.instructions.md](./instructions/i18n-system.instructions.md)
 - User stories (online + offline): [user-stories.instructions.md](./instructions/user-stories.instructions.md)
 - Frontend API client architecture: [frontend/src/services/api/README.md](../frontend/src/services/api/README.md)
+- **GitHub Milestone**: <https://github.com/test3207/m3w/milestone/1>
+- **GitHub Project Board**: <https://github.com/users/test3207/projects/3>
 - Vite Documentation: <https://vitejs.dev/>
 - React Router Documentation: <https://reactrouter.com/>
 - Hono Documentation: <https://hono.dev/>
@@ -74,5 +77,5 @@
 - Tailwind CSS: <https://tailwindcss.com/docs>
 - TypeScript Handbook: <https://www.typescriptlang.org/docs/>
 
-**Document Version**: v4.1  
-**Last Updated**: 2025-11-19
+**Document Version**: v4.2  
+**Last Updated**: 2025-11-25

--- a/.github/instructions/development-standards.instructions.md
+++ b/.github/instructions/development-standards.instructions.md
@@ -223,6 +223,84 @@ docker run -d --name m3w-rc --network m3w_default -p 4000:4000 \
 - **All PR content must be in English** (title, description, comments) for consistency and broader collaboration.
 - Only commit or push when explicitly requested; keep the working state ready for commits at all times.
 
+## Project Management
+
+### Structure Overview
+
+The project uses a **two-layer management structure**:
+
+```
+Milestone (deadline-driven)
+└── Epic (feature domain aggregation)
+    └── Issue (specific task)
+```
+
+### Resources
+
+| Resource | URL | Purpose |
+|----------|-----|----------|
+| **Milestone 1** | https://github.com/test3207/m3w/milestone/1 | Core Product Release & Deployment Automation (Due: 2025-11-30) |
+| **Project Board** | https://github.com/users/test3207/projects/3 | Kanban view for task tracking |
+
+### Epics (Milestone 1)
+
+| Epic | Issue # | Description |
+|------|---------|-------------|
+| Epic 1: Core User Experience | #29 | Online & offline features, Guest mode, PWA |
+| Epic 2: Production & Demo | #30 | Docker, demo mode, open source prep |
+| Epic 3: CI/CD Pipeline | #31 | Automated builds, tests, cloud deployment |
+| Epic 4: Quality | #38 | Bug fixes, testing improvements |
+
+### Issue Management Rules
+
+1. **Milestone only links Epics**: Individual issues are NOT directly linked to Milestone
+2. **Epic tracks sub-issues via checklist**: Each Epic body contains `- [x] #XX` checklist for progress tracking
+3. **Issue references Epic in body**: Use "Parent Issue: Epic X (#YY)" in issue description
+4. **GitHub auto-calculates progress**: Epic checklist shows completion percentage
+
+### Working with Issues
+
+**Creating a new Issue:**
+```bash
+# Create issue and link to Epic via body text
+gh issue create --title "Feature description" --body "Parent Issue: Epic 1 (#29)"
+
+# Then update the Epic checklist manually or via MCP
+```
+
+**Updating Epic progress:**
+```typescript
+// Use MCP to update Epic body with new checklist item
+mcp_github_issue_write({
+  method: 'update',
+  owner: 'test3207',
+  repo: 'm3w',
+  issue_number: 29,
+  body: `...existing content...
+- [ ] #XX New sub-issue`
+})
+```
+
+**Closing an Issue:**
+- Use `Closes #XX` in PR description or commit message
+- Update Epic checklist: change `- [ ] #XX` to `- [x] #XX`
+
+### CLI Quick Reference
+
+```bash
+# List all issues by state
+gh issue list --state all
+
+# List issues in milestone
+gh api repos/test3207/m3w/milestones
+
+# View Epic details
+gh issue view 29
+
+# Check milestone progress
+gh api repos/test3207/m3w/milestones/1 --jq '{title, open_issues, closed_issues, due_on}'
+```
+
 ## Pull Request Management
 
 ### Monitoring PR Checks


### PR DESCRIPTION
## Summary

Add project management documentation to development standards instructions.

## Changes

### development-standards.instructions.md

New **Project Management** section includes:

- **Structure Overview**: Two-layer management (Milestone → Epic → Issue)
- **Resources**: Links to Milestone 1 and Project Board
- **Epics (Milestone 1)**: Table of all 4 epics with descriptions
- **Issue Management Rules**: How to link issues to epics via checklist
- **Working with Issues**: CLI examples for creating, updating, and closing
- **CLI Quick Reference**: Common `gh` commands for issue management

### copilot-instructions.md

- Updated Instruction Index to mention project management
- Added "Managing issues, epics, or milestones?" guidance
- Added GitHub Milestone and Project Board links to References
- Updated version to v4.2

## Why

Provides clear documentation for:
- Understanding the two-layer project structure
- Creating and managing issues with proper Epic linkage
- Tracking progress via Epic checklists
- Using CLI tools for project management