### PR TITLE
fix: library sorting error in online mode

### DIFF
--- a/backend/src/routes/libraries.ts
+++ b/backend/src/routes/libraries.ts
@@ -5,7 +5,7 @@
 
 import { Hono } from 'hono';
 import { z } from 'zod';
-import pinyin from 'pinyin';
+import { pinyin } from 'pinyin';
 import { prisma } from '../lib/prisma';
 import { logger } from '../lib/logger';
 import { authMiddleware } from '../lib/auth-middleware';
@@ -341,7 +341,7 @@ app.delete('/:id', async (c: Context) => {
 
 // Helper function to get Pinyin for sorting
 function getPinyinSort(text: string): string {
-  const pinyinArray = pinyin(text || '', { style: pinyin.STYLE_NORMAL });
+  const pinyinArray = pinyin(text || '');
   return pinyinArray.flat().join('').toLowerCase();
 }
 


### PR DESCRIPTION
## Summary

Fixes the "Library not found" error when sorting songs in online mode.

## Root Cause

Two separate issues were causing the problem:

### 1. Backend: Incorrect `pinyin` import (500 error)

The `pinyin` library API changed. The old code used:
```typescript
import pinyin from 'pinyin';
pinyin(text, { style: pinyin.STYLE_NORMAL });
```

But the new API requires:
```typescript
import { pinyin } from 'pinyin';
pinyin(text);  // style option no longer needed
```

This caused all non-date sorting options (title, artist, album) to throw exceptions.

### 2. Frontend: Race condition in useEffect

The original code combined library fetch and songs fetch in a single `useEffect`:
- Changing sort option triggered a full refetch including library
- This caused "Library not found" errors due to timing issues

## Changes

### Backend (`backend/src/routes/libraries.ts`)
- Fix `pinyin` import to use named export
- Remove deprecated `style: pinyin.STYLE_NORMAL` option

### Frontend (`frontend/src/pages/LibraryDetailPage.tsx`)
- Separate library fetch (Effect 1) from songs fetch (Effect 2)
- Effect 1: Only triggers on `id` change
- Effect 2: Triggers on `id` or `sortOption` change
- Add previous song count tracking to prevent unnecessary refetches after sorting
- Add `isLoadingSongs` state for better UX during sort operations

## Testing

- [x] All 6 sorting options work correctly (date-desc, date-asc, title-asc, title-desc, artist-asc, album-asc)
- [x] Chinese songs sort by Pinyin correctly
- [x] No "Library not found" errors when changing sort
- [x] Songs refresh correctly after upload
- [x] ESLint passes
- [x] TypeScript compiles without errors

Closes #68