### PR TITLE
fix: Replace hardcoded text with i18n system

### DIFF
--- a/frontend/src/components/features/player/full-player.tsx
+++ b/frontend/src/components/features/player/full-player.tsx
@@ -198,7 +198,7 @@ export function FullPlayer() {
             className={isShuffled ? 'bg-primary/10 text-primary hover:bg-primary/20' : 'hover:bg-accent'}
           >
             <Shuffle className="h-5 w-5 mr-1.5" />
-            <span className="text-xs">随机</span>
+            <span className="text-xs">{I18n.player.shuffle.label}</span>
           </Button>
           
           <Button 
@@ -207,7 +207,7 @@ export function FullPlayer() {
             className="hover:bg-accent"
           >
             <Heart className="h-5 w-5 mr-1.5" />
-            <span className="text-xs">喜欢</span>
+            <span className="text-xs">{I18n.player.favorite.label}</span>
           </Button>
           
           <Button

--- a/frontend/src/components/features/player/play-queue-drawer.tsx
+++ b/frontend/src/components/features/player/play-queue-drawer.tsx
@@ -101,11 +101,11 @@ export function PlayQueueDrawer() {
       <SheetContent side="bottom" className="h-[80vh]">
         <SheetHeader>
           <SheetTitle>
-            播放队列 ({queue.length} 首)
+            {I18n.player.playQueue.title} ({I18n.player.playQueue.songsCount.replace('{0}', String(queue.length))})
           </SheetTitle>
           {queueSourceName && (
             <SheetDescription>
-              当前播放自：{queueSourceName}
+              {I18n.player.playQueue.playingFrom.replace('{0}', queueSourceName)}
             </SheetDescription>
           )}
         </SheetHeader>
@@ -120,7 +120,7 @@ export function PlayQueueDrawer() {
                 disabled={queue.length === 0}
               >
                 <Save className="mr-2 h-4 w-4" />
-                保存为播放列表
+                {I18n.player.playQueue.saveAsPlaylistButton}
               </Button>
               <Button
                 variant="outline"
@@ -129,7 +129,7 @@ export function PlayQueueDrawer() {
                 disabled={queue.length === 0}
               >
                 <Trash2 className="mr-2 h-4 w-4" />
-                清空队列
+                {I18n.player.playQueue.clearQueueButton}
               </Button>
             </>
           ) : (
@@ -162,7 +162,7 @@ export function PlayQueueDrawer() {
                   setPlaylistName('');
                 }}
               >
-                取消
+                {I18n.common.cancelButton}
               </Button>
             </div>
           )}
@@ -170,8 +170,8 @@ export function PlayQueueDrawer() {
 
         {queue.length === 0 ? (
           <div className="mt-8 text-center text-muted-foreground">
-            <p>队列为空</p>
-            <p className="mt-2 text-sm">从音乐库或播放列表选择歌曲</p>
+            <p>{I18n.player.playQueue.emptyTitle}</p>
+            <p className="mt-2 text-sm">{I18n.player.playQueue.emptyDescription}</p>
           </div>
         ) : (
           <div className="mt-4 space-y-2 overflow-y-auto pb-20">
@@ -208,7 +208,7 @@ export function PlayQueueDrawer() {
                   <p className="truncate font-medium">
                     {song.title}
                     {index === currentIndex && (
-                      <span className="ml-2 text-xs text-primary">● 正在播放</span>
+                      <span className="ml-2 text-xs text-primary">● {I18n.player.playQueue.nowPlaying}</span>
                     )}
                   </p>
                   <p className="truncate text-sm text-muted-foreground">

--- a/frontend/src/components/features/pwa/install-prompt.tsx
+++ b/frontend/src/components/features/pwa/install-prompt.tsx
@@ -7,6 +7,8 @@ import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { logger } from '@/lib/logger-client';
+import { I18n } from '@/locales/i18n';
+import { useLocale } from '@/locales/use-locale';
 
 interface BeforeInstallPromptEvent extends Event {
   prompt: () => Promise<void>;
@@ -14,6 +16,7 @@ interface BeforeInstallPromptEvent extends Event {
 }
 
 export function InstallPrompt() {
+  useLocale();
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [showPrompt, setShowPrompt] = useState(false);
 
@@ -79,17 +82,17 @@ export function InstallPrompt() {
     <div className="fixed bottom-4 left-4 z-50 max-w-md animate-in slide-in-from-bottom-5">
       <Card>
         <CardHeader>
-          <CardTitle>Install M3W</CardTitle>
+          <CardTitle>{I18n.settings.storage.pwa.installPrompt.title}</CardTitle>
           <CardDescription>
-            Install the app for faster access and offline support
+            {I18n.settings.storage.pwa.installPrompt.description}
           </CardDescription>
         </CardHeader>
         <CardFooter className="flex gap-2">
           <Button onClick={handleInstall}>
-            Install
+            {I18n.settings.storage.pwa.installPrompt.install}
           </Button>
           <Button variant="outline" onClick={handleDismiss}>
-            Not Now
+            {I18n.settings.storage.pwa.installPrompt.notNow}
           </Button>
         </CardFooter>
       </Card>

--- a/frontend/src/components/features/pwa/reload-prompt.tsx
+++ b/frontend/src/components/features/pwa/reload-prompt.tsx
@@ -6,8 +6,11 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { useServiceWorker } from '@/hooks/useServiceWorker';
+import { I18n } from '@/locales/i18n';
+import { useLocale } from '@/locales/use-locale';
 
 export function ReloadPrompt() {
+  useLocale();
   const { offlineReady, needRefresh, updateServiceWorker, close } = useServiceWorker();
 
   if (!offlineReady && !needRefresh) {
@@ -19,22 +22,24 @@ export function ReloadPrompt() {
       <Card>
         <CardHeader>
           <CardTitle>
-            {needRefresh ? 'New Version Available' : 'App Ready to Work Offline'}
+            {needRefresh 
+              ? I18n.settings.storage.pwa.reloadPrompt.newVersionTitle 
+              : I18n.settings.storage.pwa.reloadPrompt.offlineReadyTitle}
           </CardTitle>
           <CardDescription>
             {needRefresh
-              ? 'Click reload to update to the latest version'
-              : 'Your music library is now available offline'}
+              ? I18n.settings.storage.pwa.reloadPrompt.newVersionDescription
+              : I18n.settings.storage.pwa.reloadPrompt.offlineReadyDescription}
           </CardDescription>
         </CardHeader>
         <CardFooter className="flex gap-2">
           {needRefresh && (
             <Button onClick={() => updateServiceWorker(true)}>
-              Reload
+              {I18n.settings.storage.pwa.reloadPrompt.reload}
             </Button>
           )}
           <Button variant="outline" onClick={close}>
-            Close
+            {I18n.settings.storage.pwa.reloadPrompt.close}
           </Button>
         </CardFooter>
       </Card>

--- a/frontend/src/locales/generated/types.d.ts
+++ b/frontend/src/locales/generated/types.d.ts
@@ -573,6 +573,12 @@ export interface Messages {
       enable: string;
       /** Disable shuffle */
       disable: string;
+      /** Shuffle */
+      label: string;
+    };
+    favorite: {
+      /** Favorite */
+      label: string;
     };
     state: {
       /** Repeat: Off */
@@ -589,6 +595,16 @@ export interface Messages {
     playQueue: {
       /** Play Queue */
       title: string;
+      /** {0} songs */
+      songsCount: string;
+      /** Playing from: {0} */
+      playingFrom: string;
+      /** Now Playing */
+      nowPlaying: string;
+      /** Queue is empty */
+      emptyTitle: string;
+      /** Select songs from a library or playlist */
+      emptyDescription: string;
       /** Play Queue */
       fallbackSource: string;
       /** Removed from queue */
@@ -766,6 +782,30 @@ export interface Messages {
         notInstalled: string;
         /** Progressive Web App enables offline music playback */
         description: string;
+        installPrompt: {
+          /** Install M3W */
+          title: string;
+          /** Install the app for faster access and offline support */
+          description: string;
+          /** Install */
+          install: string;
+          /** Not Now */
+          notNow: string;
+        };
+        reloadPrompt: {
+          /** New Version Available */
+          newVersionTitle: string;
+          /** App Ready to Work Offline */
+          offlineReadyTitle: string;
+          /** Click reload to update to the latest version */
+          newVersionDescription: string;
+          /** Your music library is now available offline */
+          offlineReadyDescription: string;
+          /** Reload */
+          reload: string;
+          /** Close */
+          close: string;
+        };
       };
       /** Browser Storage */
       globalTitle: string;
@@ -957,6 +997,8 @@ export interface Messages {
         /** Removal failed */
         errorTitle: string;
       };
+      /** Add songs from your libraries to this playlist */
+      addFromLibrary: string;
     };
   };
   demo: {

--- a/frontend/src/locales/messages/en.json
+++ b/frontend/src/locales/messages/en.json
@@ -316,7 +316,11 @@
     },
     "shuffle": {
       "enable": "Enable shuffle",
-      "disable": "Disable shuffle"
+      "disable": "Disable shuffle",
+      "label": "Shuffle"
+    },
+    "favorite": {
+      "label": "Favorite"
     },
     "state": {
       "repeatOff": "Repeat: Off",
@@ -327,6 +331,11 @@
     },
     "playQueue": {
       "title": "Play Queue",
+      "songsCount": "{0} songs",
+      "playingFrom": "Playing from: {0}",
+      "nowPlaying": "Now Playing",
+      "emptyTitle": "Queue is empty",
+      "emptyDescription": "Select songs from a library or playlist",
       "fallbackSource": "Play Queue",
       "removeFromQueueTitle": "Removed from queue",
       "clearQueueTitle": "Queue cleared",
@@ -423,7 +432,21 @@
         "title": "PWA Status",
         "installed": "Installed",
         "notInstalled": "Not Installed",
-        "description": "Progressive Web App enables offline music playback"
+        "description": "Progressive Web App enables offline music playback",
+        "installPrompt": {
+          "title": "Install M3W",
+          "description": "Install the app for faster access and offline support",
+          "install": "Install",
+          "notNow": "Not Now"
+        },
+        "reloadPrompt": {
+          "newVersionTitle": "New Version Available",
+          "offlineReadyTitle": "App Ready to Work Offline",
+          "newVersionDescription": "Click reload to update to the latest version",
+          "offlineReadyDescription": "Your music library is now available offline",
+          "reload": "Reload",
+          "close": "Close"
+        }
       },
       "globalTitle": "Browser Storage",
       "globalNote": "Shared across all accounts on this device",
@@ -537,7 +560,8 @@
       "removeSong": {
         "successTitle": "Removed: {0}",
         "errorTitle": "Removal failed"
-      }
+      },
+      "addFromLibrary": "Add songs from your libraries to this playlist"
     }
   },
   "demo": {

--- a/frontend/src/locales/messages/zh-CN.json
+++ b/frontend/src/locales/messages/zh-CN.json
@@ -223,11 +223,11 @@
       "sortAlbumAsc": "专辑 A-Z",
       "loadingLabel": "加载中...",
       "deleteSong": {
-        "button": "Delete Song",
-        "successTitle": "Deleted successfully",
-        "successDescription": "Removed \"{0}\" from library",
-        "errorTitle": "Deletion failed",
-        "unknownError": "Unknown error"
+        "button": "删除歌曲",
+        "successTitle": "删除成功",
+        "successDescription": "已从音乐库中删除\"{0}\"",
+        "errorTitle": "删除失败",
+        "unknownError": "未知错误"
       }
     },
     "addToPlaylist": {
@@ -316,7 +316,11 @@
     },
     "shuffle": {
       "enable": "开启随机播放",
-      "disable": "关闭随机播放"
+      "disable": "关闭随机播放",
+      "label": "随机"
+    },
+    "favorite": {
+      "label": "喜欢"
     },
     "state": {
       "repeatOff": "循环：关闭",
@@ -327,6 +331,11 @@
     },
     "playQueue": {
       "title": "播放队列",
+      "songsCount": "{0} 首",
+      "playingFrom": "当前播放自：{0}",
+      "nowPlaying": "正在播放",
+      "emptyTitle": "队列为空",
+      "emptyDescription": "从音乐库或播放列表选择歌曲",
       "fallbackSource": "播放队列",
       "removeFromQueueTitle": "已从队列移除",
       "clearQueueTitle": "队列已清空",
@@ -423,7 +432,21 @@
         "title": "PWA 状态",
         "installed": "已安装",
         "notInstalled": "未安装",
-        "description": "PWA 应用可实现离线音乐播放"
+        "description": "PWA 应用可实现离线音乐播放",
+        "installPrompt": {
+          "title": "安装 M3W",
+          "description": "安装应用以获得更快的访问速度和离线支持",
+          "install": "安装",
+          "notNow": "稍后再说"
+        },
+        "reloadPrompt": {
+          "newVersionTitle": "新版本可用",
+          "offlineReadyTitle": "已准备好离线使用",
+          "newVersionDescription": "点击重新加载以更新到最新版本",
+          "offlineReadyDescription": "您的音乐库现已可离线使用",
+          "reload": "重新加载",
+          "close": "关闭"
+        }
       },
       "globalTitle": "浏览器存储",
       "globalNote": "此设备上所有账户共享",
@@ -537,7 +560,8 @@
       "removeSong": {
         "successTitle": "已移除：{0}",
         "errorTitle": "移除失败"
-      }
+      },
+      "addFromLibrary": "从音乐库添加歌曲到此播放列表"
     }
   },
   "demo": {

--- a/frontend/src/pages/LibraryDetailPage.tsx
+++ b/frontend/src/pages/LibraryDetailPage.tsx
@@ -228,7 +228,7 @@ export default function LibraryDetailPage() {
           )}
         </h1>
         <p className="text-sm text-muted-foreground mt-1">
-          {songs.length} 首歌曲
+          {I18n.libraries.detail.songsCount.replace('{0}', String(songs.length))}
         </p>
       </div>
 
@@ -240,7 +240,7 @@ export default function LibraryDetailPage() {
           className="flex-1"
         >
           <Play className="mr-2 h-4 w-4" />
-          播放全部
+          {I18n.libraries.detail.playAll}
         </Button>
 
         <DropdownMenu>
@@ -252,27 +252,27 @@ export default function LibraryDetailPage() {
           <DropdownMenuContent align="end">
             <DropdownMenuItem onClick={() => setSortOption("date-desc")}>
               {sortOption === "date-desc" && "✓ "}
-              添加时间 (最新)
+              {I18n.libraries.detail.sort.dateDesc}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => setSortOption("date-asc")}>
               {sortOption === "date-asc" && "✓ "}
-              添加时间 (最旧)
+              {I18n.libraries.detail.sort.dateAsc}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => setSortOption("title-asc")}>
               {sortOption === "title-asc" && "✓ "}
-              标题 A-Z
+              {I18n.libraries.detail.sort.titleAsc}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => setSortOption("title-desc")}>
               {sortOption === "title-desc" && "✓ "}
-              标题 Z-A
+              {I18n.libraries.detail.sort.titleDesc}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => setSortOption("artist-asc")}>
               {sortOption === "artist-asc" && "✓ "}
-              歌手 A-Z
+              {I18n.libraries.detail.sort.artistAsc}
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => setSortOption("album-asc")}>
               {sortOption === "album-asc" && "✓ "}
-              专辑 A-Z
+              {I18n.libraries.detail.sort.albumAsc}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -280,8 +280,8 @@ export default function LibraryDetailPage() {
 
       {/* Current Sort */}
       <p className="mb-4 text-xs text-muted-foreground">
-        排序方式: {getSortLabel(sortOption)}
-        {isLoadingSongs && " (加载中...)"}
+        {I18n.libraries.detail.sort.label.replace('{0}', getSortLabel(sortOption))}
+        {isLoadingSongs && ` (${I18n.common.loadingLabel})`}
       </p>
 
       {/* Song List */}
@@ -289,9 +289,9 @@ export default function LibraryDetailPage() {
         <div className="flex min-h-[50vh] items-center justify-center">
           <div className="text-center">
             <ListPlus className="mx-auto h-16 w-16 text-muted-foreground/50" />
-            <h2 className="mt-4 text-xl font-semibold">还没有歌曲</h2>
+            <h2 className="mt-4 text-xl font-semibold">{I18n.libraries.detail.empty.title}</h2>
             <p className="mt-2 text-sm text-muted-foreground">
-              点击右下角 "+" 上传歌曲到这个音乐库
+              {I18n.libraries.detail.empty.description}
             </p>
           </div>
         </div>
@@ -357,7 +357,7 @@ export default function LibraryDetailPage() {
                     className="text-destructive focus:text-destructive"
                   >
                     <Trash2 className="mr-2 h-4 w-4" />
-                    删除歌曲
+                    {I18n.libraries.detail.deleteSong.button}
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/frontend/src/pages/PlaylistDetailPage.tsx
+++ b/frontend/src/pages/PlaylistDetailPage.tsx
@@ -264,7 +264,7 @@ export default function PlaylistDetailPage() {
   if (!currentPlaylist) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-muted-foreground">播放列表不存在</p>
+        <p className="text-muted-foreground">{I18n.playlists.detail.notFound}</p>
       </div>
     );
   }
@@ -279,7 +279,7 @@ export default function PlaylistDetailPage() {
               {currentPlaylist.name}
             </h1>
             <p className="text-xs text-muted-foreground">
-              {songs.length} 首歌曲
+              {I18n.playlists.detail.songsCount.replace('{0}', String(songs.length))}
             </p>
           </div>
 
@@ -291,7 +291,7 @@ export default function PlaylistDetailPage() {
               className="shrink-0"
             >
               <Play className="h-4 w-4 mr-1.5" />
-              播放全部
+              {I18n.playlists.detail.playAll}
             </Button>
           )}
         </div>
@@ -305,16 +305,16 @@ export default function PlaylistDetailPage() {
               <div className="flex flex-col items-center justify-center gap-4 text-center">
                 <Music className="h-12 w-12 text-muted-foreground/50" />
                 <div>
-                  <h3 className="font-semibold mb-1">播放列表为空</h3>
+                  <h3 className="font-semibold mb-1">{I18n.playlists.detail.empty.title}</h3>
                   <p className="text-sm text-muted-foreground">
-                    从音乐库添加歌曲到此播放列表
+                    {I18n.playlists.detail.addFromLibrary}
                   </p>
                 </div>
                 <Button
                   variant="outline"
                   onClick={() => navigate("/libraries")}
                 >
-                  浏览音乐库
+                  {I18n.playlists.detail.empty.browseButton}
                 </Button>
               </div>
             </Card>


### PR DESCRIPTION
## Summary

Replace all hardcoded Chinese and English text with proper i18n system usage.

## Changes

### New i18n Keys Added

**Player Controls:**
- `player.shuffle.label` - Shuffle button text
- `player.favorite.label` - Favorite button text

**Play Queue:**
- `player.playQueue.songsCount` - Songs count display
- `player.playQueue.playingFrom` - Source indicator
- `player.playQueue.nowPlaying` - Now playing indicator
- `player.playQueue.emptyTitle` - Empty queue title
- `player.playQueue.emptyDescription` - Empty queue description

**PWA Prompts:**
- `settings.storage.pwa.reloadPrompt.*` - 6 keys for reload prompt
- `settings.storage.pwa.installPrompt.*` - 4 keys for install prompt

**Library/Playlist Detail:**
- `libraries.detail.sort.*` - Sort options and label
- `libraries.detail.songsCount` - Songs count
- `libraries.detail.playAll` - Play all button
- `libraries.detail.empty.*` - Empty state
- `playlists.detail.notFound` - Not found message
- `playlists.detail.songsCount` - Songs count
- `playlists.detail.playAll` - Play all button
- `playlists.detail.addFromLibrary` - Empty state description

### Components Updated

| File | Changes |
|------|---------|
| `full-player.tsx` | Fixed 随机/喜欢 button labels |
| `play-queue-drawer.tsx` | Fixed header, buttons, empty state |
| `reload-prompt.tsx` | Fixed all 6 hardcoded English strings |
| `install-prompt.tsx` | Fixed all 4 hardcoded English strings |
| `LibraryDetailPage.tsx` | Fixed counts, buttons, sort, empty state |
| `PlaylistDetailPage.tsx` | Fixed counts, buttons, empty state |

### Translation Fixes

Fixed `zh-CN.json` where `library.detail.deleteSong.*` had English placeholders.

## Testing

- [x] `npm run i18n:build` - Success (433 keys)
- [x] `npm run lint` (frontend) - Pass
- [x] `npm run lint` (backend) - Pass

## Closes

Closes #63