### PR TITLE
fix: build shared package during setup

### DIFF
--- a/scripts/setup.cjs
+++ b/scripts/setup.cjs
@@ -277,6 +277,7 @@ function installDependencies() {
     log.error('  ✗ shared package build failed');
     process.exit(1);
   }
+  log.success('  ✓ Shared package built');
 
   // Optional: Playwright browsers
   log.gray('  Installing Playwright browsers (for testing)...');


### PR DESCRIPTION
## Summary

Add shared package build step to setup.cjs after npm install to ensure \@m3w/shared\ is compiled before running \
pm run dev\ for the first time.

## Problem

Fresh clone + \
pm run setup\ + \
pm run dev\ fails because the shared package is not built, and frontend/backend cannot import from \@m3w/shared\.

## Solution

Add build step in \installDependencies()\ function after all workspaces have \
pm install\ completed:

\\\javascript
// Build shared package (required before frontend/backend can import from it)
log.gray('  Building shared package...');
if (!exec('npm run build', { cwd: path.join(projectRoot, 'shared') })) {
  log.error('  ✗ shared package build failed');
  process.exit(1);
}
\\\

Closes #117