### PR TITLE
fix: fallback to song metadata duration when AudioPlayer not loaded

### DIFF
--- a/frontend/src/components/features/player/full-player/index.tsx
+++ b/frontend/src/components/features/player/full-player/index.tsx
@@ -222,6 +222,8 @@ export function FullPlayer() {
   };
 
   const displaySong = currentSong || lastPlayedSong;
+  // Fallback to song metadata duration when AudioPlayer hasn't loaded the track yet
+  const displayDuration = duration > 0 ? duration : (displaySong?.duration ?? 0);
   if (animationPhase === AnimationPhase.Hidden || !displaySong) return null;
 
   // Transform calculations
@@ -306,7 +308,7 @@ export function FullPlayer() {
 
       {/* Controls Section */}
       <Stack gap="lg" className="px-8 pb-8 pt-4 shrink-0">
-        <ProgressBar currentTime={currentTime} duration={duration} onSeek={seek} />
+        <ProgressBar currentTime={currentTime} duration={displayDuration} onSeek={seek} />
         <PlaybackControls
           isPlaying={isPlaying}
           isShuffled={isShuffled}


### PR DESCRIPTION
## Summary

When opening FullPlayer without active playback, the duration displays as `0:00` because AudioPlayer hasn't loaded the track yet. This fix falls back to the song's metadata duration for display.

## Changes

- Added `displayDuration` variable that uses song metadata duration as fallback
- Pass `displayDuration` to ProgressBar instead of raw `duration` from store

## Root Cause

The `duration` in playerStore comes from AudioPlayer events, but when restoring a session without starting playback:
- `currentSong` / `lastPlayedSong` has `duration` in its metadata (from database)
- `playerStore.duration` is 0 because AudioPlayer hasn't loaded the track yet

## Solution

```typescript
const displayDuration = duration > 0 ? duration : (displaySong?.duration ?? 0);
```

Closes #147
