### PR TITLE
chore: enable scheduled RC branch creation

### DIFF
--- a/.github/workflows/create-rc-branch.yml
+++ b/.github/workflows/create-rc-branch.yml
@@ -1,20 +1,16 @@
 name: Create RC Branch
 
 # Creates a new RC branch from main for release candidate testing
-#
-# TODO: Re-enable scheduled trigger after full CI/CD testing is complete
-# See: https://github.com/test3207/m3w/issues/83
 
 on:
-  # TEMPORARILY DISABLED - Uncomment after testing complete
-  # schedule:
-  #   # Run every Tuesday at 10:00 AM Beijing time (China Standard Time, UTC+8)
-  #   # Beijing 10:00 AM = UTC 02:00 AM (10 - 8 = 2)
-  #   # Day of week: 0=Sunday, 1=Monday, 2=Tuesday, 3=Wednesday, 4=Thursday, 5=Friday, 6=Saturday
-  #   # Status badge: https://github.com/test3207/m3w/actions/workflows/create-rc-branch.yml/badge.svg
-  #   - cron: '0 2 * * 2'
+  schedule:
+    # Run every Tuesday at 10:00 AM Beijing time (China Standard Time, UTC+8)
+    # Beijing 10:00 AM = UTC 02:00 AM (10 - 8 = 2)
+    # Day of week: 0=Sunday, 1=Monday, 2=Tuesday, 3=Wednesday, 4=Thursday, 5=Friday, 6=Saturday
+    # Status badge: https://github.com/test3207/m3w/actions/workflows/create-rc-branch.yml/badge.svg
+    - cron: '0 2 * * 2'
   
-  # Manual trigger for testing
+  # Manual trigger
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Enable the scheduled trigger for `create-rc-branch.yml` workflow now that v1.0.0 has been released and CI/CD pipeline is fully tested.

Closes #83

## Changes

- Uncommented the schedule trigger (every Tuesday 10:00 AM Beijing time)
- Removed TODO comment referencing issue #83
- Changed "Manual trigger for testing" to "Manual trigger"

## Testing

All CI workflows have been manually tested during the v1.0.0 release cycle:
- ✅ `create-rc-branch.yml` - manual trigger works
- ✅ `build-rc.yml` - builds from RC branch
- ✅ `increment-rc-branch.yml` - creates new RC from existing
- ✅ `build-release.yml` - production release flow (v1.0.0 released successfully)
- ✅ Docker images pushed correctly to GHCR
- ✅ GitHub Releases created with archives