### PR TITLE
chore: use Deploy Key for ruleset bypass in release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -232,15 +232,29 @@ jobs:
       
       - name: Cherry-pick version bump to main
         if: ${{ !inputs.dry_run }}
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         run: |
           git config user.name "github-actions[bot]"
           # 41898282 is the official GitHub user ID for github-actions[bot]
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           
+          # Configure SSH for Deploy Key (bypasses branch protection ruleset)
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "Host github.com" >> ~/.ssh/config
+          echo "  IdentityFile ~/.ssh/deploy_key" >> ~/.ssh/config
+          echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+          
+          # Switch remote to SSH for ruleset bypass
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+          
           BUMP_COMMIT="${{ steps.prod_branch.outputs.bump_commit }}"
           
+          git fetch origin main
           git checkout main
-          git pull origin main
+          git reset --hard origin/main
           
           # Cherry-pick the version bump commit
           if git cherry-pick "$BUMP_COMMIT" --no-edit; then


### PR DESCRIPTION
## Summary

Configure the release workflow to use Deploy Key for pushing version bump to main, bypassing the branch protection ruleset.

Closes #166

## Background

After enabling branch protection ruleset, the `build-release.yml` workflow's "Cherry-pick version bump to main" step would fail because `GITHUB_TOKEN` doesn't have bypass permission.

## Changes

- Switch from `GITHUB_TOKEN` to `DEPLOY_KEY` (ssh-key) for checkout
- Use `git fetch` + `git reset --hard` instead of `git pull` for cleaner operation
- Added comment explaining the Deploy Key's role

## Prerequisites

- ✅ Deploy Key added to repository (with write access)
- ✅ `DEPLOY_KEY` secret configured with private key
- ✅ Deploy Keys added to ruleset bypass list