### PR TITLE
feat(player): redesign FullPlayer gestures with @use-gesture/react

### DIFF
--- a/frontend/src/components/features/player/full-player/constants.ts
+++ b/frontend/src/components/features/player/full-player/constants.ts
@@ -9,10 +9,14 @@
 
 /** Gesture configuration for swipe and drag interactions */
 export const GESTURE_CONFIG = {
-  /** Minimum swipe distance to trigger close (pixels) */
+  /** Minimum swipe distance to trigger action (pixels) */
   SWIPE_THRESHOLD: 100,
+  /** Minimum velocity to trigger action (ratio) */
+  VELOCITY_THRESHOLD: 0.3,
   /** Drag resistance factor (0-1, lower = more resistance) */
   DRAG_RESISTANCE: 0.6,
+  /** Horizontal drag resistance (more resistance for subtle feedback) */
+  HORIZONTAL_DRAG_RESISTANCE: 0.3,
   /** Maximum drag distance for opacity calculation (pixels) */
   MAX_DRAG_FOR_OPACITY: 200,
   /** Minimum opacity during drag */


### PR DESCRIPTION
## Summary

Redesigns FullPlayer gesture handling using `@use-gesture/react` for more intuitive music player controls.

## Gesture Mapping (Option A from #172)

| Gesture | Action |
|---------|--------|
| Swipe Left | Next track |
| Swipe Right | Previous track |
| Swipe Down | Close player |
| Swipe Up | Open play queue |

## Changes

- Replace manual `touchStart/Move/End` handlers with `useDrag` from `@use-gesture/react`
- Add velocity-based gesture detection for more responsive feel
- Horizontal swipes now control track navigation (more intuitive for music players)
- Maintain visual feedback for downward drag (opacity reduction)
- Skip gesture handling when interacting with slider or buttons

## Testing

- [x] TypeScript compilation passes
- [x] ESLint passes
- [ ] Manual testing: swipe left for next track
- [ ] Manual testing: swipe right for previous track
- [ ] Manual testing: swipe down to close
- [ ] Manual testing: swipe up for queue

## Related

Closes #172

Parent Issue: Epic 10: Mobile Touch & Gesture Quality (#169)