### PR TITLE
feat(load-tests): add k6 load testing scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,11 @@ node_modules
 # Vitest browser mode screenshots (generated next to test files)
 **/__screenshots__/
 
+# k6 load test outputs
+tests/load/results/
+tests/load/*.json
+tests/load/*.html
+
 # vite
 dev-dist/
 dist/

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,240 @@
+# M3W Load Testing
+
+k6 load testing scripts for M3W music player backend.
+
+## Prerequisites
+
+1. **Install k6**: https://k6.io/docs/get-started/installation/
+
+   ```bash
+   # macOS
+   brew install k6
+
+   # Windows (winget)
+   winget install k6
+
+   # Windows (choco)
+   choco install k6
+
+   # Linux (Debian/Ubuntu)
+   sudo gpg -k
+   sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+   echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+   sudo apt-get update
+   sudo apt-get install k6
+   ```
+
+2. **Running M3W instance**: The tests target a live M3W deployment.
+
+3. **Test user credentials**: GitHub OAuth token or test user setup.
+
+## Directory Structure
+
+```
+tests/load/
+├── README.md           # This file
+├── config.js           # Shared configuration
+├── scripts/
+│   ├── api.js          # API load test (CRUD operations)
+│   ├── streaming.js    # Audio streaming test
+│   ├── upload.js       # File upload test
+│   └── helpers.js      # Shared utilities
+└── data/
+    └── .gitkeep        # Test audio files (not committed)
+```
+
+## Configuration
+
+Edit `config.js` to set your target environment:
+
+```javascript
+export const CONFIG = {
+  BASE_URL: 'http://localhost:4000',
+  // ... other settings
+};
+```
+
+Or use environment variables:
+
+```bash
+export K6_BASE_URL=http://localhost:4000
+export K6_ACCESS_TOKEN=your-jwt-token
+```
+
+## Running Tests
+
+### Quick Start (Smoke Test)
+
+```bash
+# Run a quick smoke test (1 VU, 30s)
+k6 run tests/load/scripts/api.js --env SMOKE=true
+```
+
+### API Load Test
+
+```bash
+# Default: 10 VUs, 1 minute
+k6 run tests/load/scripts/api.js
+
+# Custom VUs and duration
+k6 run tests/load/scripts/api.js --vus 50 --duration 5m
+
+# With access token
+k6 run tests/load/scripts/api.js --env ACCESS_TOKEN=eyJhbG...
+```
+
+### Audio Streaming Test
+
+```bash
+# Requires at least one song in the database
+k6 run tests/load/scripts/streaming.js --env SONG_ID=clxxxxx
+
+# Test with multiple songs
+k6 run tests/load/scripts/streaming.js --env SONG_IDS=id1,id2,id3
+```
+
+### Upload Test
+
+```bash
+# Requires test audio files in tests/load/data/
+k6 run tests/load/scripts/upload.js --env LIBRARY_ID=clxxxxx
+```
+
+### Full Suite
+
+```bash
+# Run all tests sequentially
+k6 run tests/load/scripts/api.js && \
+k6 run tests/load/scripts/streaming.js && \
+k6 run tests/load/scripts/upload.js
+```
+
+## Test Scenarios
+
+### 1. API Load Test (`api.js`)
+
+Simulates typical API usage patterns:
+
+| Scenario | Weight | Operations |
+|----------|--------|------------|
+| Browse | 60% | List libraries, playlists, songs |
+| Playback | 30% | Get song metadata, update progress |
+| Manage | 10% | Create/update/delete operations |
+
+### 2. Streaming Test (`streaming.js`)
+
+Tests audio streaming performance:
+
+- Full file downloads
+- Range requests (seek simulation)
+- Concurrent streams
+- Various file sizes (3-15MB)
+
+### 3. Upload Test (`upload.js`)
+
+Tests file upload pipeline:
+
+- Single file uploads
+- Concurrent uploads
+- Metadata extraction timing
+- Large file handling
+
+## Metrics & Thresholds
+
+Default thresholds (configurable in each script):
+
+| Metric | Threshold | Description |
+|--------|-----------|-------------|
+| `http_req_duration` | p(95) < 500ms | 95th percentile response time |
+| `http_req_failed` | < 1% | Error rate |
+| `http_reqs` | - | Requests per second (informational) |
+
+### Custom Metrics
+
+Each test exports custom metrics:
+
+- `api_browse_duration` - Time to list resources
+- `api_crud_duration` - Time for CRUD operations
+- `stream_ttfb` - Time to first byte for streaming
+- `stream_throughput` - Bytes per second
+- `upload_duration` - Total upload time
+
+## Output Formats
+
+### Console Summary (default)
+
+```bash
+k6 run tests/load/scripts/api.js
+```
+
+### JSON Output
+
+```bash
+k6 run tests/load/scripts/api.js --out json=results.json
+```
+
+### InfluxDB (for Grafana dashboards)
+
+```bash
+k6 run tests/load/scripts/api.js --out influxdb=http://localhost:8086/k6
+```
+
+### Cloud (k6 Cloud)
+
+```bash
+k6 cloud tests/load/scripts/api.js
+```
+
+## CI Integration
+
+Example GitHub Actions workflow:
+
+```yaml
+- name: Run Load Tests
+  run: |
+    k6 run tests/load/scripts/api.js \
+      --env BASE_URL=${{ secrets.TEST_BASE_URL }} \
+      --env ACCESS_TOKEN=${{ secrets.TEST_ACCESS_TOKEN }} \
+      --out json=k6-results.json
+```
+
+## Interpreting Results
+
+### Good Performance
+
+```
+✓ http_req_duration..............: avg=45ms  p(95)=120ms
+✓ http_req_failed................: 0.00%
+  http_reqs......................: 15000  250/s
+```
+
+### Performance Issues
+
+```
+✗ http_req_duration..............: avg=850ms p(95)=2.5s   ← Too slow
+✗ http_req_failed................: 5.2%                   ← High error rate
+  http_reqs......................: 3000   50/s            ← Low throughput
+```
+
+## Troubleshooting
+
+### "Connection refused"
+
+- Ensure M3W is running at the configured BASE_URL
+- Check firewall/network settings
+
+### "401 Unauthorized"
+
+- Provide valid ACCESS_TOKEN
+- Token may have expired (6h default)
+
+### "No songs found"
+
+- Upload test songs first
+- Provide SONG_ID or SONG_IDS environment variable
+
+## References
+
+- [k6 Documentation](https://k6.io/docs/)
+- [k6 Thresholds](https://k6.io/docs/using-k6/thresholds/)
+- [k6 Metrics](https://k6.io/docs/using-k6/metrics/)

--- a/tests/load/config.js
+++ b/tests/load/config.js
@@ -1,0 +1,122 @@
+/**
+ * M3W Load Test Configuration
+ *
+ * Configuration can be overridden via environment variables:
+ *   k6 run script.js --env BASE_URL=http://example.com
+ */
+
+// Base configuration
+export const CONFIG = {
+  // Target server URL
+  BASE_URL: __ENV.BASE_URL || __ENV.K6_BASE_URL || 'http://localhost:4000',
+
+  // Authentication
+  ACCESS_TOKEN: __ENV.ACCESS_TOKEN || __ENV.K6_ACCESS_TOKEN || '',
+
+  // Test data IDs (comma-separated for multiple)
+  LIBRARY_ID: __ENV.LIBRARY_ID || '',
+  PLAYLIST_ID: __ENV.PLAYLIST_ID || '',
+  SONG_ID: __ENV.SONG_ID || '',
+  SONG_IDS: __ENV.SONG_IDS ? __ENV.SONG_IDS.split(',') : [],
+
+  // Test mode
+  SMOKE: __ENV.SMOKE === 'true',
+  DEBUG: __ENV.DEBUG === 'true',
+};
+
+// Default load test options
+export const DEFAULT_OPTIONS = {
+  // Smoke test: quick validation
+  smoke: {
+    vus: 1,
+    duration: '30s',
+    thresholds: {
+      http_req_duration: ['p(95)<1000'],
+      http_req_failed: ['rate<0.05'],
+    },
+  },
+
+  // Load test: normal traffic simulation
+  load: {
+    stages: [
+      { duration: '30s', target: 10 }, // Ramp up
+      { duration: '1m', target: 10 }, // Steady state
+      { duration: '30s', target: 20 }, // Peak
+      { duration: '30s', target: 0 }, // Ramp down
+    ],
+    thresholds: {
+      http_req_duration: ['p(95)<500', 'p(99)<1000'],
+      http_req_failed: ['rate<0.01'],
+    },
+  },
+
+  // Stress test: find breaking point
+  stress: {
+    stages: [
+      { duration: '1m', target: 20 },
+      { duration: '2m', target: 50 },
+      { duration: '2m', target: 100 },
+      { duration: '1m', target: 0 },
+    ],
+    thresholds: {
+      http_req_duration: ['p(95)<2000'],
+      http_req_failed: ['rate<0.10'],
+    },
+  },
+
+  // Soak test: long-running stability
+  soak: {
+    stages: [
+      { duration: '2m', target: 20 },
+      { duration: '30m', target: 20 },
+      { duration: '2m', target: 0 },
+    ],
+    thresholds: {
+      http_req_duration: ['p(95)<500'],
+      http_req_failed: ['rate<0.01'],
+    },
+  },
+};
+
+// Get options based on test mode
+export function getOptions(testType = 'load') {
+  if (CONFIG.SMOKE) {
+    return DEFAULT_OPTIONS.smoke;
+  }
+
+  const mode = __ENV.TEST_MODE || testType;
+  return DEFAULT_OPTIONS[mode] || DEFAULT_OPTIONS.load;
+}
+
+// API endpoints
+export const ENDPOINTS = {
+  // Health
+  health: '/health',
+  ready: '/ready',
+
+  // Auth
+  authMe: '/api/auth/me',
+  authRefresh: '/api/auth/refresh',
+
+  // Libraries
+  libraries: '/api/libraries',
+  library: (id) => `/api/libraries/${id}`,
+  librarySongs: (id) => `/api/libraries/${id}/songs`,
+
+  // Playlists
+  playlists: '/api/playlists',
+  playlist: (id) => `/api/playlists/${id}`,
+  playlistSongs: (id) => `/api/playlists/${id}/songs`,
+
+  // Songs
+  song: (id) => `/api/songs/${id}`,
+  songStream: (id) => `/api/songs/${id}/stream`,
+  songCover: (id) => `/api/songs/${id}/cover`,
+
+  // Upload
+  upload: '/api/upload',
+
+  // Player
+  playerPreferences: '/api/player/preferences',
+  playerProgress: '/api/player/progress',
+};

--- a/tests/load/data/.gitkeep
+++ b/tests/load/data/.gitkeep
@@ -1,0 +1,11 @@
+# Test data directory
+# 
+# Place test audio files here for upload tests.
+# These files are git-ignored to avoid committing large binaries.
+#
+# Recommended test files:
+# - small.mp3  (~3MB)
+# - medium.mp3 (~7MB)
+# - large.mp3  (~15MB)
+#
+# You can use any MP3 files you have rights to use for testing.

--- a/tests/load/scripts/api.js
+++ b/tests/load/scripts/api.js
@@ -1,0 +1,267 @@
+/**
+ * M3W API Load Test
+ *
+ * Tests typical API usage patterns:
+ * - Browse: List libraries, playlists, songs (60%)
+ * - Playback: Get song metadata, update progress (30%)
+ * - Manage: Create/update/delete operations (10%)
+ *
+ * Usage:
+ *   k6 run tests/load/scripts/api.js
+ *   k6 run tests/load/scripts/api.js --env SMOKE=true
+ *   k6 run tests/load/scripts/api.js --vus 50 --duration 5m
+ */
+
+import { sleep, group } from 'k6';
+import { Trend, Counter, Rate } from 'k6/metrics';
+import { CONFIG, ENDPOINTS, getOptions } from '../config.js';
+import {
+  authGet,
+  authPost,
+  authPut,
+  authDelete,
+  checkResponse,
+  parseJson,
+  randomItem,
+  randomString,
+  weightedRandom,
+  verifySetup,
+} from './helpers.js';
+
+// Custom metrics
+const browseDuration = new Trend('api_browse_duration', true);
+const playbackDuration = new Trend('api_playback_duration', true);
+const crudDuration = new Trend('api_crud_duration', true);
+const apiErrors = new Counter('api_errors');
+const successRate = new Rate('api_success_rate');
+
+// Test options
+export const options = getOptions('load');
+
+// Setup: verify server is reachable
+export function setup() {
+  verifySetup();
+
+  // Fetch initial data for test
+  const data = {
+    libraries: [],
+    playlists: [],
+    songs: [],
+  };
+
+  if (CONFIG.ACCESS_TOKEN) {
+    // Get libraries
+    const libRes = authGet(ENDPOINTS.libraries);
+    if (libRes.status === 200) {
+      const json = parseJson(libRes);
+      data.libraries = json?.data || [];
+    }
+
+    // Get playlists
+    const playlistRes = authGet(ENDPOINTS.playlists);
+    if (playlistRes.status === 200) {
+      const json = parseJson(playlistRes);
+      data.playlists = json?.data || [];
+    }
+
+    // Get songs from first library
+    if (data.libraries.length > 0) {
+      const songsRes = authGet(ENDPOINTS.librarySongs(data.libraries[0].id));
+      if (songsRes.status === 200) {
+        const json = parseJson(songsRes);
+        data.songs = json?.data || [];
+      }
+    }
+
+    console.log(
+      `Setup complete: ${data.libraries.length} libraries, ${data.playlists.length} playlists, ${data.songs.length} songs`
+    );
+  } else {
+    console.log('No ACCESS_TOKEN provided, running unauthenticated tests only');
+  }
+
+  return data;
+}
+
+// Main test function
+export default function (data) {
+  // Select scenario based on weight
+  const scenario = weightedRandom([
+    { weight: 60, value: 'browse' },
+    { weight: 30, value: 'playback' },
+    { weight: 10, value: 'manage' },
+  ]);
+
+  switch (scenario) {
+    case 'browse':
+      browseScenario(data);
+      break;
+    case 'playback':
+      playbackScenario(data);
+      break;
+    case 'manage':
+      manageScenario(data);
+      break;
+  }
+
+  // Think time between iterations
+  sleep(Math.random() * 2 + 1);
+}
+
+/**
+ * Browse scenario: List libraries, playlists, songs
+ */
+function browseScenario(data) {
+  group('Browse', () => {
+    // List libraries
+    const libStart = Date.now();
+    const libRes = authGet(ENDPOINTS.libraries);
+    browseDuration.add(Date.now() - libStart);
+
+    const libSuccess = checkResponse(libRes, 'List libraries');
+    successRate.add(libSuccess);
+    if (!libSuccess) apiErrors.add(1);
+
+    sleep(0.5);
+
+    // List playlists
+    const playlistStart = Date.now();
+    const playlistRes = authGet(ENDPOINTS.playlists);
+    browseDuration.add(Date.now() - playlistStart);
+
+    const playlistSuccess = checkResponse(playlistRes, 'List playlists');
+    successRate.add(playlistSuccess);
+    if (!playlistSuccess) apiErrors.add(1);
+
+    sleep(0.5);
+
+    // Get songs from a library
+    const library = randomItem(data.libraries);
+    if (library) {
+      const songsStart = Date.now();
+      const songsRes = authGet(ENDPOINTS.librarySongs(library.id));
+      browseDuration.add(Date.now() - songsStart);
+
+      const songsSuccess = checkResponse(songsRes, 'List library songs');
+      successRate.add(songsSuccess);
+      if (!songsSuccess) apiErrors.add(1);
+    }
+  });
+}
+
+/**
+ * Playback scenario: Get song metadata, update progress
+ */
+function playbackScenario(data) {
+  group('Playback', () => {
+    const song = randomItem(data.songs);
+
+    if (!song) {
+      // Fallback: just get preferences
+      const prefStart = Date.now();
+      const prefRes = authGet(ENDPOINTS.playerPreferences);
+      playbackDuration.add(Date.now() - prefStart);
+
+      const prefSuccess = checkResponse(prefRes, 'Get preferences');
+      successRate.add(prefSuccess);
+      if (!prefSuccess) apiErrors.add(1);
+      return;
+    }
+
+    // Get song metadata
+    const metaStart = Date.now();
+    const metaRes = authGet(ENDPOINTS.song(song.id));
+    playbackDuration.add(Date.now() - metaStart);
+
+    const metaSuccess = checkResponse(metaRes, 'Get song metadata');
+    successRate.add(metaSuccess);
+    if (!metaSuccess) apiErrors.add(1);
+
+    sleep(0.3);
+
+    // Update playback progress (simulate playing)
+    const progressStart = Date.now();
+    const progressRes = authPut(ENDPOINTS.playerProgress, {
+      songId: song.id,
+      progress: Math.floor(Math.random() * 180), // Random progress 0-180s
+    });
+    playbackDuration.add(Date.now() - progressStart);
+
+    const progressSuccess = checkResponse(progressRes, 'Update progress');
+    successRate.add(progressSuccess);
+    if (!progressSuccess) apiErrors.add(1);
+
+    sleep(0.3);
+
+    // Get preferences
+    const prefStart = Date.now();
+    const prefRes = authGet(ENDPOINTS.playerPreferences);
+    playbackDuration.add(Date.now() - prefStart);
+
+    const prefSuccess = checkResponse(prefRes, 'Get preferences');
+    successRate.add(prefSuccess);
+    if (!prefSuccess) apiErrors.add(1);
+  });
+}
+
+/**
+ * Manage scenario: Create/update/delete operations
+ */
+function manageScenario(data) {
+  group('Manage', () => {
+    // Create a test playlist
+    const playlistName = `LoadTest_${randomString(6)}`;
+    const createStart = Date.now();
+    const createRes = authPost(ENDPOINTS.playlists, {
+      name: playlistName,
+    });
+    crudDuration.add(Date.now() - createStart);
+
+    const createSuccess = checkResponse(createRes, 'Create playlist');
+    successRate.add(createSuccess);
+    if (!createSuccess) {
+      apiErrors.add(1);
+      return;
+    }
+
+    const created = parseJson(createRes);
+    const playlistId = created?.data?.id;
+
+    if (!playlistId) {
+      apiErrors.add(1);
+      return;
+    }
+
+    sleep(0.5);
+
+    // Update the playlist
+    const updateStart = Date.now();
+    const updateRes = authPut(ENDPOINTS.playlist(playlistId), {
+      name: `${playlistName}_updated`,
+    });
+    crudDuration.add(Date.now() - updateStart);
+
+    const updateSuccess = checkResponse(updateRes, 'Update playlist');
+    successRate.add(updateSuccess);
+    if (!updateSuccess) apiErrors.add(1);
+
+    sleep(0.5);
+
+    // Delete the playlist (cleanup)
+    const deleteStart = Date.now();
+    const deleteRes = authDelete(ENDPOINTS.playlist(playlistId));
+    crudDuration.add(Date.now() - deleteStart);
+
+    const deleteSuccess = checkResponse(deleteRes, 'Delete playlist');
+    successRate.add(deleteSuccess);
+    if (!deleteSuccess) apiErrors.add(1);
+  });
+}
+
+// Teardown: cleanup and summary
+export function teardown(data) {
+  console.log('\n=== Test Summary ===');
+  console.log(`Libraries available: ${data.libraries.length}`);
+  console.log(`Playlists available: ${data.playlists.length}`);
+  console.log(`Songs available: ${data.songs.length}`);
+}

--- a/tests/load/scripts/helpers.js
+++ b/tests/load/scripts/helpers.js
@@ -1,0 +1,205 @@
+/**
+ * Shared helper functions for k6 load tests
+ */
+
+import http from 'k6/http';
+import { check, fail } from 'k6';
+import { CONFIG } from '../config.js';
+
+/**
+ * Get default headers with optional authentication
+ */
+export function getHeaders(includeAuth = true) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
+
+  if (includeAuth && CONFIG.ACCESS_TOKEN) {
+    headers['Authorization'] = `Bearer ${CONFIG.ACCESS_TOKEN}`;
+  }
+
+  return headers;
+}
+
+/**
+ * Build full URL from endpoint
+ */
+export function buildUrl(endpoint) {
+  return `${CONFIG.BASE_URL}${endpoint}`;
+}
+
+/**
+ * Make authenticated GET request
+ */
+export function authGet(endpoint, params = {}) {
+  const url = buildUrl(endpoint);
+  const response = http.get(url, {
+    headers: getHeaders(),
+    ...params,
+  });
+
+  if (CONFIG.DEBUG) {
+    console.log(`GET ${endpoint} -> ${response.status}`);
+  }
+
+  return response;
+}
+
+/**
+ * Make authenticated POST request
+ */
+export function authPost(endpoint, body, params = {}) {
+  const url = buildUrl(endpoint);
+  const response = http.post(url, JSON.stringify(body), {
+    headers: getHeaders(),
+    ...params,
+  });
+
+  if (CONFIG.DEBUG) {
+    console.log(`POST ${endpoint} -> ${response.status}`);
+  }
+
+  return response;
+}
+
+/**
+ * Make authenticated PUT request
+ */
+export function authPut(endpoint, body, params = {}) {
+  const url = buildUrl(endpoint);
+  const response = http.put(url, JSON.stringify(body), {
+    headers: getHeaders(),
+    ...params,
+  });
+
+  if (CONFIG.DEBUG) {
+    console.log(`PUT ${endpoint} -> ${response.status}`);
+  }
+
+  return response;
+}
+
+/**
+ * Make authenticated DELETE request
+ */
+export function authDelete(endpoint, params = {}) {
+  const url = buildUrl(endpoint);
+  const response = http.del(url, null, {
+    headers: getHeaders(),
+    ...params,
+  });
+
+  if (CONFIG.DEBUG) {
+    console.log(`DELETE ${endpoint} -> ${response.status}`);
+  }
+
+  return response;
+}
+
+/**
+ * Check if response is successful (2xx)
+ */
+export function isSuccess(response) {
+  return response.status >= 200 && response.status < 300;
+}
+
+/**
+ * Parse JSON response safely
+ */
+export function parseJson(response) {
+  try {
+    return JSON.parse(response.body);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Standard response checks
+ */
+export function checkResponse(response, name) {
+  return check(response, {
+    [`${name}: status is 2xx`]: (r) => isSuccess(r),
+    [`${name}: response time < 500ms`]: (r) => r.timings.duration < 500,
+  });
+}
+
+/**
+ * Get a random item from array
+ */
+export function randomItem(array) {
+  if (!array || array.length === 0) return null;
+  return array[Math.floor(Math.random() * array.length)];
+}
+
+/**
+ * Generate random string
+ */
+export function randomString(length = 8) {
+  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  let result = '';
+  for (let i = 0; i < length; i++) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+}
+
+/**
+ * Sleep with random jitter
+ */
+export function sleepWithJitter(baseMs, jitterMs = 100) {
+  const jitter = Math.random() * jitterMs * 2 - jitterMs;
+  const duration = Math.max(0, baseMs + jitter);
+  return new Promise((resolve) => setTimeout(resolve, duration));
+}
+
+/**
+ * Weighted random selection
+ * @param {Array<{weight: number, value: any}>} items
+ */
+export function weightedRandom(items) {
+  const totalWeight = items.reduce((sum, item) => sum + item.weight, 0);
+  let random = Math.random() * totalWeight;
+
+  for (const item of items) {
+    random -= item.weight;
+    if (random <= 0) {
+      return item.value;
+    }
+  }
+
+  return items[items.length - 1].value;
+}
+
+/**
+ * Format bytes to human readable
+ */
+export function formatBytes(bytes) {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
+}
+
+/**
+ * Setup function to verify test prerequisites
+ */
+export function verifySetup() {
+  // Check health endpoint
+  const healthRes = http.get(buildUrl('/health'));
+  if (!isSuccess(healthRes)) {
+    fail(`Server not reachable at ${CONFIG.BASE_URL}`);
+  }
+
+  // Check authentication if token provided
+  if (CONFIG.ACCESS_TOKEN) {
+    const authRes = authGet('/api/auth/me');
+    if (!isSuccess(authRes)) {
+      console.warn('Warning: ACCESS_TOKEN may be invalid or expired');
+    }
+  }
+
+  console.log(`✓ Setup verified: ${CONFIG.BASE_URL}`);
+}

--- a/tests/load/scripts/streaming.js
+++ b/tests/load/scripts/streaming.js
@@ -1,0 +1,255 @@
+/**
+ * M3W Audio Streaming Load Test
+ *
+ * Tests audio streaming performance:
+ * - Full file downloads
+ * - Range requests (seek simulation)
+ * - Concurrent streams
+ * - Time to first byte (TTFB)
+ *
+ * Usage:
+ *   k6 run tests/load/scripts/streaming.js --env SONG_ID=clxxxxx
+ *   k6 run tests/load/scripts/streaming.js --env SONG_IDS=id1,id2,id3
+ */
+
+import http from 'k6/http';
+import { sleep, group, check } from 'k6';
+import { Trend, Counter, Gauge } from 'k6/metrics';
+import { CONFIG, ENDPOINTS, getOptions } from '../config.js';
+import {
+  buildUrl,
+  getHeaders,
+  authGet,
+  parseJson,
+  randomItem,
+  formatBytes,
+  verifySetup,
+} from './helpers.js';
+
+// Custom metrics
+const streamTtfb = new Trend('stream_ttfb', true);
+const streamDuration = new Trend('stream_duration', true);
+const streamThroughput = new Gauge('stream_throughput_bps');
+const rangeRequestDuration = new Trend('range_request_duration', true);
+const streamErrors = new Counter('stream_errors');
+
+// Test options - streaming is more resource intensive
+export const options = {
+  ...getOptions('load'),
+  thresholds: {
+    ...getOptions('load').thresholds,
+    stream_ttfb: ['p(95)<200'], // TTFB under 200ms
+    stream_duration: ['p(95)<5000'], // Full stream under 5s
+  },
+};
+
+// Setup: get available songs
+export function setup() {
+  verifySetup();
+
+  const data = {
+    songs: [],
+  };
+
+  // Use provided song IDs
+  if (CONFIG.SONG_IDS.length > 0) {
+    data.songs = CONFIG.SONG_IDS.map((id) => ({ id }));
+    console.log(`Using ${data.songs.length} provided song IDs`);
+    return data;
+  }
+
+  if (CONFIG.SONG_ID) {
+    data.songs = [{ id: CONFIG.SONG_ID }];
+    console.log(`Using single song ID: ${CONFIG.SONG_ID}`);
+    return data;
+  }
+
+  // Fetch songs from API
+  if (CONFIG.ACCESS_TOKEN) {
+    const libRes = authGet(ENDPOINTS.libraries);
+    if (libRes.status === 200) {
+      const libs = parseJson(libRes)?.data || [];
+      if (libs.length > 0) {
+        const songsRes = authGet(ENDPOINTS.librarySongs(libs[0].id));
+        if (songsRes.status === 200) {
+          data.songs = parseJson(songsRes)?.data || [];
+        }
+      }
+    }
+  }
+
+  if (data.songs.length === 0) {
+    console.warn(
+      'No songs available. Provide SONG_ID or SONG_IDS environment variable.'
+    );
+  } else {
+    console.log(`Setup complete: ${data.songs.length} songs available`);
+  }
+
+  return data;
+}
+
+// Main test function
+export default function (data) {
+  if (data.songs.length === 0) {
+    console.log('Skipping: No songs available');
+    sleep(1);
+    return;
+  }
+
+  const song = randomItem(data.songs);
+
+  // Randomly choose test type
+  const testType = Math.random();
+
+  if (testType < 0.4) {
+    fullStreamTest(song);
+  } else if (testType < 0.8) {
+    rangeRequestTest(song);
+  } else {
+    seekSimulationTest(song);
+  }
+
+  sleep(Math.random() * 2 + 0.5);
+}
+
+/**
+ * Test: Full audio stream download
+ */
+function fullStreamTest(song) {
+  group('Full Stream', () => {
+    const url = buildUrl(ENDPOINTS.songStream(song.id));
+    const headers = getHeaders();
+
+    const startTime = Date.now();
+    const response = http.get(url, {
+      headers,
+      responseType: 'binary',
+    });
+    const duration = Date.now() - startTime;
+
+    // Record metrics
+    streamTtfb.add(response.timings.waiting);
+    streamDuration.add(duration);
+
+    const bodySize = response.body ? response.body.byteLength || 0 : 0;
+    if (duration > 0 && bodySize > 0) {
+      const throughput = (bodySize * 8) / (duration / 1000); // bits per second
+      streamThroughput.add(throughput);
+    }
+
+    const success = check(response, {
+      'Full stream: status is 200': (r) => r.status === 200,
+      'Full stream: has content': (r) =>
+        r.body && (r.body.byteLength || r.body.length) > 0,
+      'Full stream: content-type is audio': (r) =>
+        r.headers['Content-Type']?.includes('audio') ||
+        r.headers['content-type']?.includes('audio'),
+    });
+
+    if (!success) {
+      streamErrors.add(1);
+      if (CONFIG.DEBUG) {
+        console.log(`Stream failed: ${response.status} - ${response.body}`);
+      }
+    }
+
+    if (CONFIG.DEBUG) {
+      console.log(
+        `Full stream: ${formatBytes(bodySize)} in ${duration}ms (TTFB: ${response.timings.waiting}ms)`
+      );
+    }
+  });
+}
+
+/**
+ * Test: Range request (partial content)
+ */
+function rangeRequestTest(song) {
+  group('Range Request', () => {
+    const url = buildUrl(ENDPOINTS.songStream(song.id));
+    const headers = {
+      ...getHeaders(),
+      Range: 'bytes=0-65535', // First 64KB
+    };
+
+    const startTime = Date.now();
+    const response = http.get(url, {
+      headers,
+      responseType: 'binary',
+    });
+    const duration = Date.now() - startTime;
+
+    rangeRequestDuration.add(duration);
+    streamTtfb.add(response.timings.waiting);
+
+    const success = check(response, {
+      'Range request: status is 206 or 200': (r) =>
+        r.status === 206 || r.status === 200,
+      'Range request: has content': (r) =>
+        r.body && (r.body.byteLength || r.body.length) > 0,
+    });
+
+    if (!success) {
+      streamErrors.add(1);
+    }
+
+    if (CONFIG.DEBUG) {
+      const bodySize = response.body ? response.body.byteLength || 0 : 0;
+      console.log(
+        `Range request: ${formatBytes(bodySize)} in ${duration}ms (status: ${response.status})`
+      );
+    }
+  });
+}
+
+/**
+ * Test: Seek simulation (multiple range requests)
+ */
+function seekSimulationTest(song) {
+  group('Seek Simulation', () => {
+    // Simulate user seeking through a song
+    const seekPositions = [0, 0.25, 0.5, 0.75, 0.9]; // Seek to different parts
+    const chunkSize = 65536; // 64KB per request
+
+    for (const position of seekPositions) {
+      // Calculate byte offset (assume ~5MB file)
+      const fileSize = 5 * 1024 * 1024;
+      const startByte = Math.floor(fileSize * position);
+      const endByte = startByte + chunkSize - 1;
+
+      const url = buildUrl(ENDPOINTS.songStream(song.id));
+      const headers = {
+        ...getHeaders(),
+        Range: `bytes=${startByte}-${endByte}`,
+      };
+
+      const startTime = Date.now();
+      const response = http.get(url, {
+        headers,
+        responseType: 'binary',
+      });
+      const duration = Date.now() - startTime;
+
+      rangeRequestDuration.add(duration);
+
+      const success = check(response, {
+        [`Seek ${Math.floor(position * 100)}%: status ok`]: (r) =>
+          r.status === 206 || r.status === 200,
+      });
+
+      if (!success) {
+        streamErrors.add(1);
+      }
+
+      // Small delay between seeks
+      sleep(0.2);
+    }
+  });
+}
+
+// Teardown
+export function teardown(data) {
+  console.log('\n=== Streaming Test Summary ===');
+  console.log(`Songs tested: ${data.songs.length}`);
+}

--- a/tests/load/scripts/upload.js
+++ b/tests/load/scripts/upload.js
@@ -1,0 +1,226 @@
+/**
+ * M3W Upload Load Test
+ *
+ * Tests file upload performance:
+ * - Single file uploads
+ * - Concurrent uploads
+ * - Metadata extraction timing
+ * - Various file sizes
+ *
+ * Prerequisites:
+ * - Test audio files in tests/load/data/ directory
+ * - Valid ACCESS_TOKEN
+ * - LIBRARY_ID to upload to
+ *
+ * Usage:
+ *   k6 run tests/load/scripts/upload.js --env LIBRARY_ID=clxxxxx
+ */
+
+import http from 'k6/http';
+import { sleep, group, check } from 'k6';
+import { Trend, Counter, Rate } from 'k6/metrics';
+import { CONFIG, ENDPOINTS, getOptions } from '../config.js';
+import {
+  buildUrl,
+  getHeaders,
+  authGet,
+  parseJson,
+  randomItem,
+  randomString,
+  formatBytes,
+  verifySetup,
+} from './helpers.js';
+
+// Custom metrics
+const uploadDuration = new Trend('upload_duration', true);
+const uploadThroughput = new Trend('upload_throughput_bps', true);
+const metadataExtractionTime = new Trend('metadata_extraction_time', true);
+const uploadErrors = new Counter('upload_errors');
+const uploadSuccess = new Rate('upload_success_rate');
+
+// Test options - uploads are slow, use fewer VUs
+export const options = {
+  ...getOptions('load'),
+  // Override for upload tests
+  stages: CONFIG.SMOKE
+    ? undefined
+    : [
+        { duration: '30s', target: 5 },
+        { duration: '1m', target: 5 },
+        { duration: '30s', target: 0 },
+      ],
+  thresholds: {
+    upload_duration: ['p(95)<30000'], // 30s for large files
+    upload_success_rate: ['rate>0.95'],
+    http_req_failed: ['rate<0.05'],
+  },
+};
+
+// Generate synthetic audio-like data
+function generateTestAudioData(sizeBytes) {
+  // Create a buffer that mimics MP3 structure
+  // This is synthetic data - not a valid MP3, but tests upload mechanics
+  const data = new Uint8Array(sizeBytes);
+
+  // MP3 frame header (simplified)
+  data[0] = 0xff;
+  data[1] = 0xfb;
+  data[2] = 0x90;
+  data[3] = 0x00;
+
+  // Fill rest with pseudo-random data
+  for (let i = 4; i < sizeBytes; i++) {
+    data[i] = Math.floor(Math.random() * 256);
+  }
+
+  return data;
+}
+
+// Test file configurations
+const TEST_FILES = [
+  { name: 'small', size: 3 * 1024 * 1024 }, // 3MB
+  { name: 'medium', size: 7 * 1024 * 1024 }, // 7MB
+  { name: 'large', size: 15 * 1024 * 1024 }, // 15MB
+];
+
+// Setup
+export function setup() {
+  verifySetup();
+
+  const data = {
+    libraryId: CONFIG.LIBRARY_ID,
+    testFiles: [],
+  };
+
+  // Get library ID if not provided
+  if (!data.libraryId && CONFIG.ACCESS_TOKEN) {
+    const libRes = authGet(ENDPOINTS.libraries);
+    if (libRes.status === 200) {
+      const libs = parseJson(libRes)?.data || [];
+      if (libs.length > 0) {
+        data.libraryId = libs[0].id;
+        console.log(`Using library: ${libs[0].name} (${data.libraryId})`);
+      }
+    }
+  }
+
+  if (!data.libraryId) {
+    console.warn(
+      'No library ID available. Provide LIBRARY_ID environment variable.'
+    );
+  }
+
+  if (!CONFIG.ACCESS_TOKEN) {
+    console.warn('No ACCESS_TOKEN provided. Upload tests require authentication.');
+  }
+
+  // Pre-generate test data (only in setup, not per iteration)
+  // Note: k6 doesn't persist large data well between setup and default
+  // So we generate per-iteration instead
+
+  console.log('Setup complete. Test files will be generated per iteration.');
+  return data;
+}
+
+// Main test function
+export default function (data) {
+  if (!data.libraryId) {
+    console.log('Skipping: No library ID');
+    sleep(1);
+    return;
+  }
+
+  if (!CONFIG.ACCESS_TOKEN) {
+    console.log('Skipping: No access token');
+    sleep(1);
+    return;
+  }
+
+  // Select random file size
+  const fileConfig = randomItem(TEST_FILES);
+  uploadTest(data.libraryId, fileConfig);
+
+  // Longer sleep for uploads (more server-intensive)
+  sleep(Math.random() * 3 + 2);
+}
+
+/**
+ * Upload test with synthetic file
+ */
+function uploadTest(libraryId, fileConfig) {
+  group(`Upload ${fileConfig.name}`, () => {
+    // Generate test file data
+    const fileData = generateTestAudioData(fileConfig.size);
+    const fileName = `loadtest_${randomString(8)}.mp3`;
+
+    // Build multipart form data
+    const url = buildUrl(ENDPOINTS.upload);
+
+    // k6 binary file upload
+    const formData = {
+      libraryId: libraryId,
+      file: http.file(fileData, fileName, 'audio/mpeg'),
+    };
+
+    const headers = {
+      Authorization: `Bearer ${CONFIG.ACCESS_TOKEN}`,
+      // Note: Don't set Content-Type for multipart - k6 handles it
+    };
+
+    const startTime = Date.now();
+    const response = http.post(url, formData, { headers });
+    const duration = Date.now() - startTime;
+
+    uploadDuration.add(duration);
+
+    // Calculate throughput
+    const throughput = (fileConfig.size * 8) / (duration / 1000);
+    uploadThroughput.add(throughput);
+
+    // Check response
+    const success = check(response, {
+      [`Upload ${fileConfig.name}: status 200/201`]: (r) =>
+        r.status === 200 || r.status === 201,
+      [`Upload ${fileConfig.name}: has song data`]: (r) => {
+        const json = parseJson(r);
+        return json?.data?.id || json?.success;
+      },
+    });
+
+    uploadSuccess.add(success);
+    if (!success) {
+      uploadErrors.add(1);
+      if (CONFIG.DEBUG) {
+        console.log(`Upload failed: ${response.status} - ${response.body}`);
+      }
+    }
+
+    // Try to extract metadata timing from response
+    const json = parseJson(response);
+    if (json?.data?.processingTime) {
+      metadataExtractionTime.add(json.data.processingTime);
+    }
+
+    if (CONFIG.DEBUG) {
+      console.log(
+        `Upload ${fileConfig.name}: ${formatBytes(fileConfig.size)} in ${duration}ms (${formatBytes(throughput / 8)}/s)`
+      );
+    }
+
+    // Cleanup: delete uploaded file if successful
+    if (success && json?.data?.id) {
+      // Note: API may not support song deletion, so this is best-effort
+      // The files will be cleaned up manually or by the test environment reset
+    }
+  });
+}
+
+// Teardown
+export function teardown(data) {
+  console.log('\n=== Upload Test Summary ===');
+  console.log(`Library ID: ${data.libraryId || 'Not set'}`);
+  console.log('Note: Test files were synthetic (not real MP3s)');
+  console.log(
+    'Metadata extraction may fail on synthetic files - this is expected.'
+  );
+}


### PR DESCRIPTION
## Summary
Add comprehensive k6 load test suite for M3W backend performance testing.

## Test Scripts

| Script | Purpose | Scenarios |
|--------|---------|-----------|
| `api.js` | API endpoint testing | Browse (60%), Playback (30%), Manage (10%) |
| `streaming.js` | Audio streaming | Full download, Range requests, Seek simulation |
| `upload.js` | File upload | Synthetic files (3-15MB), throughput measurement |

## Files Added

- `tests/load/README.md` - Usage documentation
- `tests/load/config.js` - Shared configuration
- `tests/load/scripts/helpers.js` - Utility functions
- `tests/load/scripts/api.js` - API load test
- `tests/load/scripts/streaming.js` - Streaming test
- `tests/load/scripts/upload.js` - Upload test

## Usage

```bash
# Install k6
brew install k6  # or winget install k6

# Smoke test
k6 run tests/load/scripts/api.js --env SMOKE=true

# Full load test
k6 run tests/load/scripts/api.js --env ACCESS_TOKEN=eyJhbG...
```

## Custom Metrics

- `api_browse_duration` - Time to list resources
- `stream_ttfb` - Time to first byte
- `stream_throughput_bps` - Streaming bandwidth
- `upload_duration` - Upload completion time

Closes #180