### PR TITLE
fix: lighthouse workflow uses deploy key and removes deprecated PWA audit

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,10 +1,7 @@
 name: Lighthouse CI
 
 on:
-  # Run on releases (after deploy to demo site)
-  release:
-    types: [published]
-  # Allow manual trigger
+  # Manual trigger only (release to deploy has delay)
   workflow_dispatch:
     inputs:
       url:
@@ -53,9 +50,23 @@ jobs:
           MANIFEST_PATH: ${{ steps.lighthouse.outputs.manifest }}
       
       - name: Commit badges
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          # Configure SSH for Deploy Key (bypasses branch protection ruleset)
+          mkdir -p ~/.ssh
+          echo "$DEPLOY_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "Host github.com" >> ~/.ssh/config
+          echo "  IdentityFile ~/.ssh/deploy_key" >> ~/.ssh/config
+          echo "  StrictHostKeyChecking no" >> ~/.ssh/config
+          
+          # Switch remote to SSH for ruleset bypass
+          git remote set-url origin git@github.com:${{ github.repository }}.git
+          
           # Always commit to main branch (badges should be updated in main)
           git fetch origin main
           git checkout main

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
   <img src="https://img.shields.io/badge/Accessibility-100%25-brightgreen" alt="Lighthouse Accessibility">
   <img src="https://img.shields.io/badge/Best%20Practices-100%25-brightgreen" alt="Lighthouse Best Practices">
   <img src="https://img.shields.io/badge/SEO-100%25-brightgreen" alt="Lighthouse SEO">
-  <img src="https://img.shields.io/badge/PWA-100%25-brightgreen" alt="Lighthouse PWA">
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,7 +22,6 @@
   <img src="https://img.shields.io/badge/Accessibility-100%25-brightgreen" alt="Lighthouse Accessibility">
   <img src="https://img.shields.io/badge/Best%20Practices-100%25-brightgreen" alt="Lighthouse Best Practices">
   <img src="https://img.shields.io/badge/SEO-100%25-brightgreen" alt="Lighthouse SEO">
-  <img src="https://img.shields.io/badge/PWA-100%25-brightgreen" alt="Lighthouse PWA">
 </p>
 
 <p align="center">

--- a/assets/lighthouse/scores.json
+++ b/assets/lighthouse/scores.json
@@ -3,15 +3,13 @@
     "performance": 100,
     "accessibility": 100,
     "best-practices": 100,
-    "seo": 100,
-    "pwa": 100
+    "seo": 100
   },
   "badges": {
     "performance": "https://img.shields.io/badge/Performance-100%25-brightgreen",
     "accessibility": "https://img.shields.io/badge/Accessibility-100%25-brightgreen",
     "best-practices": "https://img.shields.io/badge/Best%20Practices-100%25-brightgreen",
-    "seo": "https://img.shields.io/badge/SEO-100%25-brightgreen",
-    "pwa": "https://img.shields.io/badge/PWA-100%25-brightgreen"
+    "seo": "https://img.shields.io/badge/SEO-100%25-brightgreen"
   },
   "timestamp": "pending",
   "note": "Initial placeholder scores. Will be updated with actual values by GitHub Actions on first Lighthouse run."

--- a/scripts/update-lighthouse-badges.cjs
+++ b/scripts/update-lighthouse-badges.cjs
@@ -46,9 +46,7 @@ function getScores(report) {
     performance: Math.round(categories.performance.score * 100),
     accessibility: Math.round(categories.accessibility.score * 100),
     'best-practices': Math.round(categories['best-practices'].score * 100),
-    seo: Math.round(categories.seo.score * 100),
-    // PWA is optional - may not be present in all Lighthouse reports
-    pwa: Math.round((categories.pwa?.score || 0) * 100)
+    seo: Math.round(categories.seo.score * 100)
   };
 }
 
@@ -85,10 +83,6 @@ function updateReadme(filePath, badges) {
   content = content.replace(
     /https:\/\/img\.shields\.io\/badge\/SEO-\d+%25-[\w-]+/g,
     badges.seo
-  );
-  content = content.replace(
-    /https:\/\/img\.shields\.io\/badge\/PWA-\d+%25-[\w-]+/g,
-    badges.pwa
   );
   
   try {
@@ -159,8 +153,7 @@ function main() {
     'performance': 'Performance',
     'accessibility': 'Accessibility',
     'best-practices': 'Best Practices',
-    'seo': 'SEO',
-    'pwa': 'PWA'
+    'seo': 'SEO'
   };
   
   // Generate badge URLs for shields.io


### PR DESCRIPTION
## Summary

Fix Lighthouse CI workflow to:
1. Use Deploy Key for pushing to main (bypasses branch protection)
2. Remove deprecated PWA audit (Lighthouse no longer scores PWA)
3. Change trigger from release to manual-only

## Changes

- **lighthouse.yml**: Use SSH with Deploy Key for push, remove release trigger
- **README.md / README.zh-CN.md**: Remove PWA badge
- **scores.json**: Remove PWA placeholder
- **update-lighthouse-badges.cjs**: Remove PWA-related code

## Why

- Branch protection was blocking workflow push
- PWA testing in Lighthouse is deprecated: https://developer.chrome.com/docs/lighthouse/pwa
- Release-to-deploy has delay, manual trigger is more reliable